### PR TITLE
Implement documentation site infrastructure with MkDocs and Material …

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,159 @@
+# Lily Architecture
+
+## Overview
+
+Lily is a spec-driven orchestration framework designed to generate structured specifications, plans, and context artifacts for handoff to external AI coding agents. The architecture emphasizes portability, clarity, and high-quality AI handoffs.
+
+## Core Principles
+
+1. **Spec-Driven**: All features start with specifications that define what, not how
+2. **AI Agent Handoffs**: Lily generates artifacts for external AI agents, not code itself
+3. **Portability**: Specifications and plans are technology-agnostic
+4. **Clarity**: Clear separation between specification, planning, and implementation
+
+## Architecture Layers
+
+### Application Layer
+
+The application layer contains command implementations that orchestrate domain logic.
+
+**Location**: `src/lily/core/application/commands/`
+
+**Commands**:
+- `InitCommand`: Initializes new Lily projects
+- `StatusCommand`: Displays project status and artifacts
+
+**Pattern**: Command pattern with structured results
+
+### Domain Layer
+
+The domain layer contains business logic and domain models (currently minimal, focused on orchestration).
+
+**Location**: `src/lily/core/domain/`
+
+### Infrastructure Layer
+
+The infrastructure layer provides concrete implementations for storage, logging, and state management.
+
+**Location**: `src/lily/core/infrastructure/`
+
+**Components**:
+- `Storage`: File system operations
+- `Logger`: Dual-format logging (Markdown + JSONL)
+- Models: `Config`, `Index`, `Log`, `State`
+
+### UI Layer
+
+The UI layer provides the CLI interface using Typer.
+
+**Location**: `src/lily/ui/cli/`
+
+**Entry Point**: `main.py` - Defines CLI commands and routes to command implementations
+
+## Project Structure
+
+```
+lily/
+├── .lily/              # System artifacts (state, index, logs, config)
+├── docs/               # User-facing documentation
+├── specs/              # Feature specifications
+├── ideas/              # Design ideas and architecture notes
+├── src/lily/           # Source code
+│   ├── core/
+│   │   ├── application/commands/  # Command implementations
+│   │   ├── domain/                # Domain logic
+│   │   └── infrastructure/        # Storage, logging, models
+│   └── ui/cli/                    # CLI interface
+└── tests/              # Test suites
+```
+
+## State Management
+
+Lily maintains project state in `.lily/state.json`:
+
+- **Phase**: Current workflow phase (DISCOVERY, SPEC, ARCH, etc.)
+- **Project Metadata**: Name, version, timestamps
+- **Artifact Tracking**: Index of all project artifacts
+
+## Artifact Types
+
+### User-Facing Artifacts
+
+Located in `docs/` directory:
+- VISION.md
+- GOALS.md
+- NON_GOALS.md
+- CONSTRAINTS.md
+- ASSUMPTIONS.md
+- OPEN_QUESTIONS.md
+
+### System Artifacts
+
+Located in `.lily/` directory:
+- `state.json`: Project state and phase
+- `index.json`: Artifact metadata
+- `config.json`: Project configuration
+- `log.md`: Human-readable audit log
+- `log.jsonl`: Machine-readable audit log
+
+## Command Flow
+
+1. **CLI Entry**: User invokes command via `lily <command>`
+2. **Validation**: Command validates prerequisites
+3. **Execution**: Command executes business logic
+4. **Storage**: Results written to file system
+5. **Logging**: Operations logged to audit logs
+6. **Result**: Structured result returned to CLI
+
+## Extension Points
+
+### Adding New Commands
+
+1. Create command class in `core/application/commands/`
+2. Implement `Command` interface (execute, validate)
+3. Add CLI entry point in `ui/cli/main.py`
+4. Create specification in `specs/`
+
+### Adding New Artifacts
+
+1. Define artifact structure
+2. Add to `InitCommand` if user-facing
+3. Update `Index` model to track
+4. Document in specification
+
+## Design Decisions
+
+### Why Two-Layer Architecture?
+
+Lily uses a simplified two-layer architecture (Application + Infrastructure) rather than traditional DDD layers:
+
+- **Simplicity**: Orchestration framework doesn't need complex domain models
+- **Clarity**: Clear separation between commands and storage
+- **Portability**: Specifications are independent of implementation
+
+### Why Dual-Format Logging?
+
+- **Markdown**: Human-readable for developers
+- **JSONL**: Machine-readable for automation and analysis
+
+### Why Command Pattern?
+
+- **Consistency**: All commands follow same interface
+- **Testability**: Easy to test command logic
+- **Extensibility**: Easy to add new commands
+
+## Future Architecture Considerations
+
+As Lily grows, consider:
+
+- **Plugin System**: For extending command capabilities
+- **TUI Layer**: Interactive terminal interface
+- **Specification Templates**: Customizable spec templates
+- **Integration Points**: Hooks for external tools
+
+## Related Documentation
+
+- [Architecture Ideas](../ideas/core/architecture.md)
+- [Two-Layer Architecture](../ideas/core/two_layer.md)
+- [UX Design](../ideas/core/ux.md)
+

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,109 @@
+# Lily Commands
+
+Lily provides a set of CLI commands to help you manage your project lifecycle from specification to implementation.
+
+## Available Commands
+
+### `lily init`
+
+Initialize a new Lily project in the current directory.
+
+**Usage:**
+```bash
+lily init <PROJECT_NAME>
+# or
+lily init --here
+```
+
+**Options:**
+- `PROJECT_NAME`: Name of the project (required unless `--here` is specified)
+- `--here`: Use current directory name as project name
+
+**What it does:**
+- Creates `.lily/` directory with system artifacts (state.json, index.json, config.json, logs)
+- Creates `docs/` directory with user-facing documentation templates:
+  - VISION.md
+  - GOALS.md
+  - NON_GOALS.md
+  - CONSTRAINTS.md
+  - ASSUMPTIONS.md
+  - OPEN_QUESTIONS.md
+- Sets initial project phase to "DISCOVERY"
+- Creates audit logs in both Markdown and JSONL formats
+
+**Example:**
+```bash
+# Initialize with project name
+lily init my-awesome-project
+
+# Initialize using current directory name
+lily init --here
+```
+
+**See also:**
+- [Init Command Specification](../specs/001-init-command/spec.md)
+- [Init Command Quickstart](../specs/001-init-command/quickstart.md)
+
+---
+
+### `lily status`
+
+Display the current project status, including phase, artifacts, and project metadata.
+
+**Usage:**
+```bash
+lily status
+```
+
+**What it shows:**
+- Current project phase (DISCOVERY, SPEC, ARCH, etc.)
+- Project name and creation date
+- List of user-facing artifacts (documentation files)
+- List of system artifacts (state, index, logs, config)
+- Project version
+
+**Example output:**
+```
+Project: my-awesome-project
+Phase: DISCOVERY
+Created: 2026-01-15
+
+User-facing artifacts:
+  ✓ docs/VISION.md
+  ✓ docs/GOALS.md
+  ...
+
+System artifacts:
+  ✓ .lily/state.json
+  ✓ .lily/index.json
+  ...
+```
+
+**See also:**
+- [Status Command Specification](../specs/001-init-command/spec.md)
+
+---
+
+## Command Architecture
+
+Lily commands follow a consistent architecture:
+
+1. **Command Interface**: CLI entry point using Typer
+2. **Command Class**: Business logic implementation
+3. **Storage Layer**: File system operations
+4. **Result Object**: Structured command results
+
+All commands:
+- Validate prerequisites before execution
+- Return structured results with success/failure status
+- Provide clear error messages
+- Log operations to audit logs
+
+## Future Commands
+
+Planned commands include:
+- `lily spec` - Generate feature specifications
+- `lily plan` - Create implementation plans
+- `lily arch` - Generate architecture documentation
+- `lily tasks` - Break down plans into actionable tasks
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,151 @@
+# Deploying Lily Documentation
+
+This guide explains how to deploy the Lily documentation site to GitHub Pages.
+
+## Prerequisites
+
+- GitHub repository set up
+- MkDocs dependencies installed: `uv sync --group docs`
+- Documentation site built: `just docs-build`
+
+## GitHub Pages Deployment
+
+### Option 1: Using mkdocs gh-deploy (Recommended)
+
+The easiest way to deploy is using MkDocs' built-in GitHub Pages deployment:
+
+```bash
+# Build and deploy in one step
+uv run mkdocs gh-deploy
+```
+
+This command:
+1. Builds the documentation site
+2. Creates/updates the `gh-pages` branch
+3. Pushes to GitHub
+4. GitHub Pages automatically serves from `gh-pages` branch
+
+**Note**: Make sure `site_url` and `repo_url` in `mkdocs.yml` are configured correctly before deploying.
+
+### Option 2: Manual Deployment
+
+If you prefer manual control:
+
+1. **Build the site**:
+   ```bash
+   just docs-build
+   ```
+
+2. **Copy to gh-pages branch**:
+   ```bash
+   git checkout --orphan gh-pages
+   git rm -rf .
+   cp -r site/* .
+   git add .
+   git commit -m "Deploy documentation"
+   git push origin gh-pages
+   git checkout main  # or your default branch
+   ```
+
+3. **Configure GitHub Pages**:
+   - Go to repository Settings → Pages
+   - Select source: `gh-pages` branch
+   - Select folder: `/ (root)`
+   - Save
+
+### Option 3: GitHub Actions (Automated)
+
+For automated deployment on every push:
+
+1. Create `.github/workflows/docs.yml`:
+   ```yaml
+   name: Deploy Documentation
+   
+   on:
+     push:
+       branches:
+         - main
+       paths:
+         - 'docs/**'
+         - 'mkdocs.yml'
+   
+   jobs:
+     deploy:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v3
+         - uses: actions/setup-python@v4
+           with:
+             python-version: '3.13'
+         - uses: astral-sh/setup-uv@v1
+         - run: uv sync --group docs
+         - run: uv run mkdocs gh-deploy --force
+           env:
+             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+   ```
+
+2. Push to trigger deployment
+
+## Configuration
+
+### Update mkdocs.yml
+
+Before deploying, update these settings in `mkdocs.yml`:
+
+```yaml
+site_url: https://yourusername.github.io/lily/  # Your GitHub Pages URL
+repo_url: https://github.com/yourusername/lily  # Your repository URL
+```
+
+The `site_url` should match your GitHub Pages URL pattern:
+- User/organization pages: `https://username.github.io/repository/`
+- Project pages: `https://username.github.io/repository/`
+
+## Troubleshooting
+
+### Site not updating
+
+- Clear browser cache
+- Check GitHub Pages settings
+- Verify `gh-pages` branch exists and has content
+- Check GitHub Actions logs (if using Actions)
+
+### Broken links
+
+- Ensure `site_url` is correct in `mkdocs.yml`
+- Use relative links in Markdown files
+- Rebuild site after changing `site_url`
+
+### 404 errors
+
+- Verify GitHub Pages is enabled
+- Check branch name matches Pages source
+- Ensure `index.html` exists in root of `gh-pages` branch
+
+## Local Testing
+
+Before deploying, test locally:
+
+```bash
+# Serve locally
+just docs-serve
+
+# Open http://127.0.0.1:8000
+# Verify all links work
+# Check search functionality
+# Test dark mode toggle
+```
+
+## Continuous Deployment
+
+For automatic deployment on every documentation update:
+
+1. Set up GitHub Actions workflow (see Option 3 above)
+2. Configure to trigger on changes to `docs/` or `mkdocs.yml`
+3. Push changes - documentation deploys automatically
+
+## Related Documentation
+
+- [Quickstart Guide](specs/002-docs-site-infrastructure/quickstart.md)
+- [MkDocs Configuration](specs/002-docs-site-infrastructure/contracts/mkdocs-config.md)
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,92 @@
+# Getting Started with Lily
+
+Lily is a spec-driven orchestration framework that helps you manage your project lifecycle from initial ideas through implementation.
+
+## Installation
+
+Lily is a Python project. Install dependencies using `uv`:
+
+```bash
+# Install all dependencies
+uv sync
+
+# Or install just runtime dependencies
+uv sync --no-dev
+```
+
+## Quick Start
+
+### 1. Initialize a Project
+
+Start by initializing a new Lily project:
+
+```bash
+# Initialize with a project name
+lily init my-project
+
+# Or use current directory name
+lily init --here
+```
+
+This creates:
+- `.lily/` directory with system artifacts
+- `docs/` directory with documentation templates
+- Initial project state set to "DISCOVERY" phase
+
+### 2. Check Project Status
+
+View your project status:
+
+```bash
+lily status
+```
+
+This shows:
+- Current project phase
+- Project metadata
+- List of artifacts (documentation and system files)
+
+### 3. Fill in Documentation
+
+Edit the files in `docs/` to define your project:
+
+- **VISION.md**: What is this project? Why does it exist?
+- **GOALS.md**: What are the primary objectives?
+- **NON_GOALS.md**: What is explicitly out of scope?
+- **CONSTRAINTS.md**: Technical, business, or time constraints
+- **ASSUMPTIONS.md**: Assumptions about technology, users, context
+- **OPEN_QUESTIONS.md**: Questions that need answers
+
+### 4. Generate Specifications
+
+Use Lily's specification workflow to create feature specs:
+
+1. Define features in natural language
+2. Lily generates structured specifications
+3. Create implementation plans
+4. Break down into actionable tasks
+5. Hand off to AI coding agents
+
+## Workflow Phases
+
+Lily projects progress through phases:
+
+1. **DISCOVERY**: Initial project setup, defining vision and goals
+2. **SPEC**: Creating feature specifications
+3. **ARCH**: Architecture design and planning
+4. **IMPLEMENT**: Implementation tasks
+5. **POLISH**: Testing, documentation, refinement
+
+## Next Steps
+
+- Read the [Architecture documentation](architecture.md) to understand Lily's design
+- Explore [Commands](commands/index.md) to see what Lily can do
+- Check out [Specifications](specs/) for examples of feature specs
+- Review [Ideas](ideas/) for design concepts and UX patterns
+
+## Getting Help
+
+- Browse the documentation sections
+- Check command help: `lily <command> --help`
+- Review specifications in `specs/` directory
+

--- a/docs/ideas/commands/command_init.md
+++ b/docs/ideas/commands/command_init.md
@@ -1,0 +1,360 @@
+Start with the **headless core skeleton**—but the *very first* work item should be the thing that forces every architectural decision to line up:
+
+## First thing to build: the “Command Pipeline Spine”
+
+Not a cross-cutting concern, not a TUI feature, not even spec generation.
+
+### Build **one vertical slice** that proves:
+
+* commands are real objects
+* state exists on disk
+* artifacts are written deterministically
+* validators can block progression
+* UI (CLI) calls the same core API you’ll later reuse in a TUI
+
+That spine becomes the rails everything else rides on.
+
+---
+
+## The first command to implement
+
+### ✅ `init` (Project bootstrap) — this is the correct first command
+
+Because it establishes:
+
+* `.lily/` workspace
+* the state machine starting state
+* the artifact folder layout
+* the logging/event channel
+* “where everything lives” for all later commands
+
+**Outputs (minimum):**
+
+* `.lily/state.json` (phase = `DISCOVERY`, project metadata)
+* `.lily/log.md` (append-only)
+* `docs/` (or `spec/`) folder
+* stub artifacts:
+
+  * `VISION.md`
+  * `GOALS.md`
+  * `NON_GOALS.md`
+  * `CONSTRAINTS.md`
+  * `OPEN_QUESTIONS.md`
+
+**Validation:** ensure empty repo? (optional), ensure paths created, ensure idempotency.
+
+---
+
+## The cross-cutting concern you *should* do first
+
+Only one: **Artifact Store + State Store**
+Because every stage needs read/write and diffs.
+
+So the order is:
+
+1. **Storage layer (filesystem + tiny index)**
+2. **Command bus + result object**
+3. **`init` command implemented end-to-end**
+4. **CLI wiring to call the command bus**
+
+That is the smallest “vertical slice” that proves the architecture.
+
+---
+
+## Why not start with spec generation?
+
+Because spec generation will tempt you into:
+
+* prompt formatting debates
+* “how smart should Lily be”
+* template complexity
+* validation complexity
+
+…and you’ll still lack the rails to ship it.
+
+---
+
+## Milestone definition (what “done” looks like)
+
+Run:
+
+```bash
+lily init myproj
+```
+
+And you get:
+
+* deterministic files created
+* a clean console result that lists files written
+* state saved to disk
+* re-running it doesn’t break anything (idempotent or safe-fail)
+* a `lily status` command can read state and print phase + artifacts present
+
+That’s it. That’s the spine.
+
+---
+
+## Immediately after `init`
+
+Second command should be:
+
+### `status`
+
+It’s tiny, but it forces you to implement:
+
+* state reading
+* artifact indexing
+* a stable query surface for the future TUI
+
+---
+
+If you want, I’ll write the exact **first sprint plan** (3–6 tasks with acceptance criteria) so you can implement this spine quickly and not drift.
+
+
+
+
+
+
+
+give me a list of alll items/artifacts init will make
+
+
+
+
+
+
+Here is the **complete, opinionated list** of artifacts that `init` should create. This is designed so **every later command depends on it**, and nothing here will need to be redesigned when you add the TUI.
+
+I’m separating **user-facing artifacts** from **system/internal artifacts** on purpose.
+
+---
+
+## User-Facing Artifacts (the “project truth”)
+
+These live in the repo and are meant to be read and edited by humans *and* AI coders later.
+
+```
+docs/
+├── VISION.md
+├── GOALS.md
+├── NON_GOALS.md
+├── CONSTRAINTS.md
+├── ASSUMPTIONS.md
+├── OPEN_QUESTIONS.md
+```
+
+### What each is for (brief but strict)
+
+* **VISION.md**
+
+  * One–two page narrative
+  * What this system *is*
+  * Who it’s for
+  * Why it exists
+
+* **GOALS.md**
+
+  * Explicit success criteria
+  * Measurable where possible
+  * Ordered by importance
+
+* **NON_GOALS.md**
+
+  * Explicit exclusions
+  * Prevents scope creep
+  * Critical for AI coder alignment
+
+* **CONSTRAINTS.md**
+
+  * Hard rules (tech, legal, performance, org)
+  * “Must / must not” language
+
+* **ASSUMPTIONS.md**
+
+  * Things believed to be true but not yet verified
+  * Forces later validation
+
+* **OPEN_QUESTIONS.md**
+
+  * Unknowns blocking later phases
+  * Should trend toward empty over time
+
+All of these should be created with:
+
+* section headers
+* guidance comments
+* empty bullet lists ready to fill
+
+---
+
+## System / Internal Artifacts (the “control plane”)
+
+These live under `.lily/` and are **never manually edited**.
+
+```
+.lily/
+├── state.json
+├── index.json
+├── log.md
+├── config.json
+├── runs/
+│   └── .gitkeep
+└── tasks/
+    └── .gitkeep
+```
+
+### Purpose of each
+
+#### `.lily/state.json`
+
+Single source of truth for workflow state.
+
+Contains:
+
+```json
+{
+  "phase": "DISCOVERY",
+  "project_name": "...",
+  "created_at": "...",
+  "last_updated": "...",
+  "version": "0.1.0"
+}
+```
+
+Used by:
+
+* `status`
+* phase gating
+* TUI indicators
+
+---
+
+#### `.lily/index.json`
+
+Artifact index + checksums.
+
+Tracks:
+
+* file path
+* artifact type
+* last modified
+* hash
+
+Used for:
+
+* change detection
+* validation
+* review diffs
+* TUI file trees
+
+---
+
+#### `.lily/log.md`
+
+Append-only audit log.
+
+Entries like:
+
+```
+[2026-01-14 19:22] init
+- created docs/VISION.md
+- created .lily/state.json
+```
+
+Used for:
+
+* traceability
+* debugging
+* explaining “why did this change?”
+
+---
+
+#### `.lily/config.json`
+
+Project-level Lily configuration.
+
+Examples:
+
+* default prompt format
+* preferred coder target
+* validation strictness
+
+Safe to grow later without breaking init.
+
+---
+
+#### `.lily/runs/`
+
+Directory for execution records.
+
+Each future AI dev run gets:
+
+```
+.lily/runs/<run_id>/
+├── task.json
+├── logs.txt
+├── summary.md
+```
+
+Empty at init, but structure must exist.
+
+---
+
+#### `.lily/tasks/`
+
+Future task storage.
+
+* May later hold per-task folders
+* Or act as backing store for a kanban view
+* Exists now so later commands don’t mutate structure
+
+---
+
+## Optional but recommended (decide once)
+
+If you want to be very clean from day one:
+
+```
+docs/README.md
+```
+
+Explains:
+
+* what the docs folder is
+* how Lily uses it
+* “don’t delete these files”
+
+---
+
+## What `init` explicitly must NOT do
+
+* ❌ Generate specs
+* ❌ Ask architecture questions
+* ❌ Write any code
+* ❌ Invoke an LLM
+* ❌ Assume language or framework
+
+Init is **pure structure + state**.
+
+---
+
+## Acceptance criteria for `init`
+
+`lily init` is correct if:
+
+* Running it twice does not corrupt state
+* All files are created deterministically
+* `lily status` can read phase + artifacts
+* Nothing here needs to change when:
+
+  * spec generation is added
+  * multiple AI devs are added
+  * TUI is added
+
+---
+
+If you want, next I can:
+
+* turn this into a **checklist + test plan**
+* write the **exact contents/templates** for each markdown file
+* define the **JSON schemas** for state/index/config

--- a/docs/ideas/core/architecture.md
+++ b/docs/ideas/core/architecture.md
@@ -1,0 +1,158 @@
+Here’s the architecture I’d ship for Lily, plus the patterns that keep it clean, portable, and not over-engineered.
+
+## Architecture patterns to use
+
+### 1) Pipeline + Stages (core)
+
+**Why:** Lily is a deterministic “document factory.” A pipeline keeps it predictable.
+
+* Each stage takes **inputs + prior artifacts**, produces **new artifacts + a short state summary**.
+* Stages are idempotent: rerun a stage, same output unless inputs changed.
+
+### 2) State Machine (workflow control)
+
+**Why:** Prevents “wandering chat” and makes progress auditable.
+States like:
+
+* `DISCOVERY → SPEC → ARCH → TASKS → PACKAGING → HANDOFF → REVIEW`
+
+### 3) Command Pattern (slash-command UX)
+
+**Why:** Matches what you like about spec-driven ecosystems.
+Commands like:
+
+* `/init`, `/spec`, `/arch`, `/tasks`, `/package`, `/handoff`, `/review`, `/amend`
+
+Each command maps to one pipeline stage and produces files.
+
+### 4) Template Method (consistent doc generation)
+
+**Why:** Every artifact should look the same every time.
+Each doc type has:
+
+* header block
+* required sections
+* validation checklist
+* “open questions” footer
+
+### 5) Strategy Pattern (swap coders, swap formats)
+
+**Why:** Tool-agnostic handoff is a core requirement.
+Pluggable strategies for:
+
+* **Coder targets:** Cursor vs Claude vs “OpenAI Codex-like”
+* **Prompt format:** XML-tagged vs Markdown blocks
+* **Repo type:** Python project vs Node vs “unknown”
+
+### 6) Gatekeeper / Quality Gate (non-negotiable)
+
+**Why:** Biggest risk is bad context.
+A validation step that checks:
+
+* spec completeness (reqs + non-goals + constraints)
+* architecture decisions recorded
+* tasks have acceptance criteria
+* handoff package is “minimal but sufficient”
+
+### 7) Event Sourcing-lite (audit trail)
+
+**Why:** You want to know *why* docs changed.
+Append-only `LOG.md` entries per command:
+
+* command run
+* inputs
+* what changed
+* unresolved questions
+
+---
+
+## Recommended app flow
+
+### The “happy path”
+
+1. **/init**
+
+   * Creates skeleton docs and a project “sCOPE.
+   * Outputs: `VISION.md`, `GOALS.md`, `NON_GOALS.md`, `CONSTRAINTS.md`
+
+2. **/spec**
+
+   * Lily interviews you briefly (or consumes your notes) and writes `SPEC.md`.
+   * Outputs: `SPEC.md`, `ASSUMPTIONS.md`, `OPEN_QUESTIONS.md`
+
+3. **/arch**
+
+   * Turns spec into structure and decisions.
+   * Outputs: `ARCHITECTURE.md`, `DATA_MODELS.md`, `INTERFACES.md`, `TECH_DECISIONS.md`
+
+4. **/tasks**
+
+   * Decomposes into implementable units for a coding agent.
+   * Outputs: `TASKS.md`, `ACCEPTANCE_CRITERIA.md`, optional `TEST_PLAN.md`
+
+5. **/package**
+
+   * Produces the “coder handoff bundle” (the *only* thing the AI coder needs).
+   * Outputs: `CODER_CONTEXT.md`, `CODING_RULES.md`, `PROMPTS/`, maybe `TASK_PACKS/T-###/`
+
+6. **/handoff**
+
+   * Lily emits a single copy/paste prompt (or a Cursor “instruction block”) referencing the bundle.
+
+7. **/review**
+
+   * After coder outputs code, Lily runs alignment checks and generates:
+   * Outputs: `REVIEW.md` (what matches spec, what deviates, what to fix)
+
+### The “iteration loop”
+
+* If review finds drift: `/amend spec` or `/amend tasks` → rerun `/package` → re-handoff.
+
+---
+
+## Concrete module layout (simple and scalable)
+
+```
+lily/
+  app.py                 # CLI/TUI entry
+  core/
+    state.py             # Workflow state machine
+    pipeline.py          # Stage runner
+    commands.py          # Command registry
+  stages/
+    discovery.py
+    spec.py
+    architecture.py
+    tasks.py
+    packaging.py
+    review.py
+  artifacts/
+    templates/           # Jinja2 or simple formatters
+    validators/          # quality gates
+  adapters/
+    coders/
+      cursor.py
+      claude.py
+      openai.py
+    formats/
+      xml_tagged.py
+      markdown_blocks.py
+  storage/
+    repo_fs.py           # writes/reads files from repo
+    diff.py              # change detection, summaries
+```
+
+Minimal dependencies: `typer` (CLI), `pydantic`, maybe `jinja2` (optional).
+
+---
+
+## The key design decision
+
+**Lily is a “document compiler,” not an agent that improvises.**
+So the architecture should optimize for:
+
+* repeatability
+* traceability
+* quality gates
+* clean handoffs
+

--- a/docs/ideas/core/initial_ideas.md
+++ b/docs/ideas/core/initial_ideas.md
@@ -1,0 +1,252 @@
+# Lily: Spec-Driven Orchestration Framework
+
+## Purpose
+
+Lily is a spec-driven orchestration system designed to **maximize AI coding quality without doing the coding herself**. Her role is to generate high-quality, structured context artifacts—specs, plans, prompts, and constraints—and hand them off to external AI coding agents such as Claude, Cursor, Gemini, or OpenAI models.
+
+The core philosophy: **great code comes from great context**.
+
+---
+
+## Design Principles
+
+1. **Separation of Concerns**
+
+   * Lily never writes production code
+   * External AI coders never decide requirements or architecture
+
+2. **Spec as the Source of Truth**
+
+   * All downstream work derives from written artifacts
+   * Specs are human-readable and AI-optimal
+
+3. **Portability First**
+
+   * No shell scripts, no OS assumptions
+   * Markdown + structured text only
+
+4. **Tool-Agnostic Handoff**
+
+   * Works equally well with Claude, Cursor, Gemini, OpenAI, or future agents
+
+5. **Phase-Specific Tooling**
+
+   * Each phase produces explicit artifacts
+   * No hidden state
+
+---
+
+## High-Level Architecture
+
+```
+Human → Lily (Orchestrator)
+      → Spec Artifacts
+      → Planning Artifacts
+      → Prompt Packages
+      → AI Coder (Claude / Cursor / etc.)
+      → Code
+```
+
+Lily operates as a **workflow driver**, not an autonomous coder.
+
+---
+
+## Development Phases
+
+### Phase 1: Discovery & Intent Capture
+
+**Goal:** Establish shared understanding
+
+**Artifacts:**
+
+* `VISION.md`
+* `GOALS.md`
+* `NON_GOALS.md`
+* `ASSUMPTIONS.md`
+* `CONSTRAINTS.md`
+
+**Inputs:**
+
+* Natural language discussion
+* Existing systems or references
+
+---
+
+### Phase 2: Specification
+
+**Goal:** Define *what* must be built
+
+**Artifacts:**
+
+* `SPEC.md`
+
+  * Functional requirements
+  * Behavioral expectations
+  * Interfaces (conceptual)
+  * Error handling expectations
+
+Specs are:
+
+* Declarative
+* Testable
+* Free of implementation details
+
+---
+
+### Phase 3: Architecture & Planning
+
+**Goal:** Define *how* it should be built
+
+**Artifacts:**
+
+* `ARCHITECTURE.md`
+* `DATA_MODELS.md`
+* `INTERFACES.md`
+* `TECH_DECISIONS.md`
+
+Includes:
+
+* Directory structure
+* Module responsibilities
+* External dependencies
+* Integration points
+
+---
+
+### Phase 4: Task Decomposition
+
+**Goal:** Create executable work units
+
+**Artifacts:**
+
+* `TASKS.md`
+* `ACCEPTANCE_CRITERIA.md`
+
+Each task:
+
+* Has a single responsibility
+* References spec sections
+* Includes validation conditions
+
+---
+
+### Phase 5: AI Coder Context Packaging
+
+**Goal:** Give AI coders everything they need, nothing they don’t
+
+**Artifacts:**
+
+* `CODER_CONTEXT.md`
+* `CODING_RULES.md`
+* `STYLE_GUIDE.md`
+* `PROMPTS/`
+
+This is the **handoff boundary**.
+
+---
+
+### Phase 6: Verification & Iteration
+
+**Goal:** Ensure alignment with spec
+
+**Artifacts:**
+
+* `TEST_PLAN.md`
+* `KNOWN_RISKS.md`
+* `OPEN_QUESTIONS.md`
+
+Feedback loops update upstream docs—not ad-hoc prompts.
+
+---
+
+## Prompting Strategy
+
+Lily uses **structured prompting** to reduce ambiguity.
+
+Example:
+
+```xml
+<role>You are an expert Python backend engineer</role>
+
+<context>
+<architecture>ARCHITECTURE.md</architecture>
+<spec>SPEC.md</spec>
+<rules>CODING_RULES.md</rules>
+</context>
+
+<task>
+Implement Task T-003 exactly as specified
+</task>
+
+<constraints>
+- No new dependencies
+- Follow style guide strictly
+</constraints>
+```
+
+This approach is sometimes referred to as:
+
+* Structured prompting
+* XML-style prompting
+* Tagged instruction prompting
+
+---
+
+## Technology Choices
+
+**Core Framework:**
+
+* LangChain (or LangGraph) for orchestration
+
+**Artifacts:**
+
+* Markdown
+* Structured text (XML-style tags)
+
+**Storage:**
+
+* Git repository as system of record
+
+**Execution:**
+
+* Human-in-the-loop
+* External AI coding tools
+
+---
+
+## What Lily Is NOT
+
+* Not a code generator
+* Not an IDE replacement
+* Not a workflow runner
+* Not OS-dependent
+
+Lily is an **architect, planner, and context engineer**.
+
+---
+
+## Biggest Risks & Mitigations
+
+| Risk                  | Mitigation                 |
+| --------------------- | -------------------------- |
+| Poor specs → bad code | Strict artifact validation |
+| Context overload      | Phase-scoped handoffs      |
+| Tool lock-in          | Tool-agnostic formats      |
+| Drift from intent     | Spec-first iteration       |
+
+---
+
+## Success Criteria
+
+* AI coders require minimal clarification
+* Code matches spec on first pass
+* Humans can audit decisions via docs
+* System works identically across tools
+
+---
+
+## North Star
+
+> **Make AI coding boring—because everything important was decided upstream.**
+
+Lily exists so creativity, architecture, and intent live in documents—not buried in chat logs.

--- a/docs/ideas/core/two_layer.md
+++ b/docs/ideas/core/two_layer.md
@@ -1,0 +1,254 @@
+Here’s a concrete software design for the **two-layer architecture** (Headless Core + UI shells) that lets you ship a CLI first and later bolt on a full TUI **without rewriting logic**.
+
+## Architecture: Headless Core + UI Shells
+
+### Layer A — Headless Core (the product)
+
+**Responsibilities**
+
+* Workflow state machine (phases)
+* Artifact generation (docs)
+* Validation gates
+* Task/Run/Worker models
+* Job scheduling + run logs
+* Persistence (filesystem + git)
+
+**Key rule:** Core exposes **commands + events**, not UI.
+
+### Layer B — UI Shells (replaceable skins)
+
+* **CLI shell**: `lily /spec`, `lily /tasks`, etc.
+* **REPL shell**: interactive session, slash commands
+* **TUI shell**: panes, kanban, logs, diffs
+
+**Key rule:** UI shells call the **same core command API**.
+
+---
+
+## Core design: “Command Bus + Use Cases + Events”
+
+### Primary module boundaries
+
+```
+core/
+  application/     # use cases (commands)
+  domain/          # entities + rules
+  infrastructure/  # filesystem, git, external tools
+ui/
+  cli/
+  repl/
+  tui/
+```
+
+### Data model (domain)
+
+* **Project**: name, root path, active phase
+* **Artifact**: path, type, checksum, updated_at
+* **Task**: id, title, spec_refs, acceptance_criteria, status, owner(worker)
+* **Worker**: id, type(cursor/claude), status, current_task
+* **Run**: id, worker_id, task_id, start/end, log stream, outcome
+
+---
+
+## Flow of the app
+
+1. UI parses user intent (command + args)
+2. UI calls **CommandBus.execute(Command)**
+3. Core:
+
+   * loads project state
+   * validates prerequisites
+   * runs use case
+   * writes artifacts
+   * records Run/Event log
+4. Core returns a structured **Result**
+5. UI renders Result (CLI prints text, TUI updates panes)
+
+---
+
+## GoF patterns to use (and where)
+
+### 1) **Command Pattern** (non-negotiable)
+
+**Purpose:** CLI and TUI both invoke the same operations.
+
+* Each action is a `Command` object:
+
+  * `InitProject`
+  * `GenerateSpec`
+  * `GenerateArchitecture`
+  * `DecomposeTasks`
+  * `PackageHandoff`
+  * `ValidateArtifacts`
+
+**CLI mapping:** `lily spec` → `GenerateSpecCommand`
+**TUI mapping:** button/keybind → `GenerateSpecCommand`
+
+### 2) **Facade** (simple API for UIs)
+
+**Purpose:** UIs talk to one object, not 30 services.
+
+* `LilyApp` facade exposes:
+
+  * `execute(command) -> Result`
+  * `subscribe(event_handler)` (optional)
+  * `get_status()`
+
+### 3) **Template Method** (consistent artifact generation)
+
+**Purpose:** All docs follow consistent structure.
+
+Base class:
+
+* `ArtifactGenerator.generate()`:
+
+  1. load template
+  2. fill sections
+  3. append metadata footer
+  4. validate required sections
+  5. write file
+
+Concrete generators:
+
+* `SpecGenerator`
+* `ArchitectureGenerator`
+* `TaskListGenerator`
+
+### 4) **Strategy** (swap backends cleanly)
+
+**Purpose:** you’ll swap “how to package” and “how to handoff.”
+
+Strategies:
+
+* `PromptFormatStrategy` (xml-tagged vs markdown blocks)
+* `CoderTargetStrategy` (Cursor vs Claude vs OpenAI)
+* `DiffStrategy` (git diff vs file diff)
+* `ValidationStrictnessStrategy` (tight vs relaxed)
+
+### 5) **State Pattern** (phase enforcement)
+
+**Purpose:** “Spec must exist before Arch” becomes enforceable logic.
+
+States:
+
+* `DiscoveryState`
+* `SpecState`
+* `ArchitectureState`
+* `TasksState`
+* `PackagingState`
+* `HandoffState`
+* `ReviewState`
+
+Each state controls allowed commands:
+
+* In `SpecState`, allow `/spec`, deny `/package` until arch/tasks exist.
+
+### 6) **Observer** (events to UI)
+
+**Purpose:** TUI needs live updates; CLI can ignore or print them.
+
+Core emits events:
+
+* `ArtifactWritten`
+* `ValidationFailed`
+* `TaskStatusChanged`
+* `RunStarted/RunCompleted`
+
+CLI subscribes → prints a line
+TUI subscribes → updates panels
+
+### 7) **Abstract Factory** (build the app with the right adapters)
+
+**Purpose:** clean composition without if-else soup.
+
+Factories create:
+
+* storage adapters (filesystem, git)
+* coder target adapters
+* prompt formatters
+
+Example:
+
+* `ProductionAppFactory`
+* `TestAppFactory`
+
+### 8) **Adapter** (external systems)
+
+**Purpose:** Cursor/Claude/OpenAI are “external services” behind a stable interface.
+
+* `CoderAdapter.send_handoff(package) -> HandoffReceipt`
+  Even if early versions just produce copy/paste text, the interface stays.
+
+---
+
+## The “shared core” API contract (what UI calls)
+
+### Command execution
+
+* `Result` contains:
+
+  * `summary` (short human-readable)
+  * `changed_files` (list)
+  * `diagnostics` (warnings/errors)
+  * `events` (optional structured)
+
+### Query endpoints (read-only)
+
+* `get_project_status()`
+* `list_tasks(filter=...)`
+* `tail_run_logs(run_id)`
+* `artifact_index()`
+
+This is what powers a TUI without reimplementing logic.
+
+---
+
+## Persistence strategy (keeps it portable)
+
+* Everything under `.lily/`:
+
+  * `.lily/state.json` (phase + pointers)
+  * `.lily/runs/<run_id>/log.txt`
+  * `.lily/index.json` (artifact index + hashes)
+  * `.lily/tasks.json` (or tasks in markdown + index)
+
+Artifacts live in the repo root or `/docs`.
+
+---
+
+## Why this design cleanly supports CLI first, TUI later
+
+* CLI and TUI share:
+
+  * **Commands**
+  * **Use cases**
+  * **Validators**
+  * **Storage**
+  * **Events**
+* Only difference is rendering + input handling
+
+So you don’t “reuse the TUI”—you reuse the **core**, and the TUI is just another client.
+
+---
+
+## If you want one “anchor” pattern to remember
+
+**Hexagonal Architecture (Ports & Adapters)** is the overarching style:
+
+* Core defines ports (storage, coder, prompt format)
+* Adapters implement them
+* UI is just another adapter
+
+(GoF patterns above plug into that style nicely.)
+
+---
+
+If you’d like, I can update your existing “Lily – Spec-driven Orchestration Architecture” doc with a new section:
+
+* **Two-Layer Architecture**
+* **Command Bus API**
+* **GoF pattern mapping**
+* **Module tree**
+* **Event model**
+
+…and keep it consistent with the rest of your design doc.

--- a/docs/ideas/core/ux.md
+++ b/docs/ideas/core/ux.md
@@ -1,0 +1,317 @@
+Short answer: **yes — they’re TUIs**, but there are a few important sub-types, and where Lily lands matters.
+
+Let me break this down cleanly, architect-style.
+
+---
+
+## What are terminal apps like Claude Code / Codex?
+
+They fall under **terminal user interfaces**, but more specifically:
+
+### 1. CLI (Command-Line Interface)
+
+**Examples:** `git`, `ripgrep`, `uv`, `pytest`
+
+* One-shot commands
+* Stateless or lightly stateful
+* Input → output → exit
+* Flags and arguments drive behavior
+
+👉 **Not what you want for Lily**
+
+---
+
+### 2. REPL-style CLI (Interactive CLI)
+
+**Examples:** `python`, `node`, `redis-cli`
+
+* Persistent session
+* Prompt → response loop
+* Minimal UI, mostly text
+
+Claude Code *partially* fits here.
+
+---
+
+### 3. TUI (Terminal User Interface)
+
+**Examples:**
+
+* Claude Code
+* Codex CLI
+* `lazygit`
+* `htop`
+* `k9s`
+
+**Characteristics:**
+
+* Persistent state
+* Panels / panes / views
+* Keyboard-driven
+* Still text-only
+* Often built with curses-style libraries
+
+👉 **This is the right mental model for Lily**
+
+---
+
+## What Claude Code actually is (important distinction)
+
+Claude Code is not “just a TUI”.
+
+It is a **Conversation-Oriented TUI with Command Overlays**:
+
+* A main conversational pane
+* Slash commands (`/spec`, `/edit`, `/test`)
+* Context-aware behavior
+* Filesystem-aware
+* Strong opinionated workflow
+
+This is exactly the design space Lily should live in.
+
+---
+
+## The correct term for Lily’s UX
+
+If you wanted to be precise (and impress architects):
+
+> **“A stateful, command-driven TUI for spec-driven orchestration.”**
+
+Or more casually:
+
+> **“A conversational TUI with phase-aware commands.”**
+
+---
+
+## Recommended UX model for Lily (strong opinion)
+
+### Lily should be a **Hybrid TUI + Command REPL**
+
+Not:
+
+* a full-screen curses dashboard
+* a flag-heavy CLI
+* a chat-only REPL
+
+Instead:
+
+### Core interaction loop
+
+```
+lily> /init
+lily> /spec
+lily> /arch
+lily> /tasks
+lily> /package
+```
+
+With:
+
+* Inline explanations
+* File diffs / summaries
+* Clear “what changed” output
+* Occasional confirmation prompts
+
+---
+
+## What Lily’s TUI should expose
+
+### 1. Conversational stream (primary)
+
+* Natural language interaction
+* Clarifying questions
+* Explanations of decisions
+
+### 2. Command layer (authoritative)
+
+Commands *always* win over chat.
+
+Examples:
+
+* `/status` → show current phase & artifacts
+* `/validate` → run quality gates
+* `/amend spec` → reopen a phase
+* `/diff ARCHITECTURE.md`
+* `/handoff cursor`
+
+---
+
+## What Lily’s TUI should *not* do
+
+* No mouse
+* No window manager complexity
+* No dependency on terminal size
+* No “dashboard for dashboards’ sake”
+
+Remember the philosophy you already set:
+
+> **Documents are the UI. The terminal is the control plane.**
+
+---
+
+## Libraries that fit this direction (when you’re ready)
+
+You don’t need to decide now, but architecturally:
+
+* **Typer** → command structure
+* **Rich / Textual** → light TUI enhancements
+* **Prompt Toolkit** → REPL + keybindings
+
+Claude Code itself uses this general stack.
+
+---
+
+## Final architectural UX decision (the one I’d lock in)
+
+**Lily is:**
+
+* A **terminal-based, conversational TUI**
+* With **slash-command-driven phases**
+* Focused on **document generation, not display**
+* Optimized for **flow, not visuals**
+
+If you want, next we can:
+
+* Design Lily’s exact command set (`/spec`, `/arch`, etc.)
+* Sketch a sample terminal session end-to-end
+* Decide whether Lily is **full-screen** or **inline prompt style** (I have a strong opinion on this too)
+
+Just say where you want to go next.
+
+
+
+
+
+
+
+
+eventually it would be great to have it tracking todos and the like. it could have several ai devs going at a time. we could split the screen to show each working perhaps. are we sure we shouldnt make a full fledged tui?
+
+
+
+
+
+
+
+You *can* go full-fledged TUI — and with your “multiple AI devs + todo tracking + panes” vision, it’s a legit direction. The trap is building a **dashboard-first** system before you’ve proven the **workflow + artifacts** are rock solid.
+
+So my architect answer is:
+
+**Yes, we should eventually build a full TUI — but only after we’ve stabilized the core orchestration loop.**
+And we can design the UX now so the transition is painless.
+
+## The real question
+
+Not “TUI or not,” but:
+
+### Do we need **concurrent operator visibility**?
+
+If Lily is coordinating multiple AI devs simultaneously, you’ll eventually want:
+
+* parallel task lanes
+* status at-a-glance
+* a queue/kanban
+* logs per agent
+* diff/patch review pane
+
+That is squarely **TUI territory**.
+
+## The biggest risk of going full TUI too early
+
+You end up spending 60–80% of your time on:
+
+* layout responsiveness
+* keybindings
+* focus management
+* scrollback + rendering
+* event loops
+  …while the real product is the **artifact pipeline + gates + handoff packaging**.
+
+So the right approach is a **two-layer design**:
+
+---
+
+## Recommended approach: “TUI Shell over a Headless Core”
+
+### Layer 1 — Headless Lily Core (must exist first)
+
+* Pipeline stages (Discovery → Spec → Arch → Tasks → Package → Review)
+* Artifact store (files + git)
+* Validator / gatekeeper
+* Scheduler for “AI dev jobs” (even if early versions just simulate concurrency)
+
+This core is 100% usable from a basic CLI.
+
+### Layer 2 — TUI Shell (built once the core is stable)
+
+* Displays state from the core
+* Starts/stops jobs
+* Shows progress logs
+* Shows todo board
+* Manages panes/tabs
+
+This ensures the TUI doesn’t become the product.
+
+---
+
+## UX design I’d pick for “multiple AI devs”
+
+### Full TUI, but **tabbed panes**, not a permanent split
+
+Splitting the screen for multiple agents sounds cool, but it’s usually worse in practice:
+
+* each pane becomes too narrow
+* logs are unreadable
+* you lose deep focus
+
+Better pattern (used by the best terminal tools):
+
+* **Left sidebar**: Projects / Tasks / Agents
+* **Main pane**: currently selected agent/task stream
+* **Right pane (toggle)**: artifact diff / spec / checklist / files
+* **Bottom strip**: status + job queue
+
+And then:
+
+* Tabs for agents (`Agent A`, `Agent B`, `Agent C`)
+* A command palette for actions (`/assign`, `/handoff`, `/validate`)
+
+You *can* allow split-view as an option, but tabs-first wins.
+
+---
+
+## What “several AI devs going at a time” means architecturally
+
+You’ll need a small internal model:
+
+* **Task** (spec reference, acceptance criteria, status)
+* **Worker** (Cursor/Claude/OpenAI instance, capabilities, current task)
+* **Run** (log stream, artifacts changed, outcome)
+* **Queue** (pending tasks, priorities)
+
+Even if the AI devs are invoked manually at first, Lily should track them like jobs.
+
+---
+
+## So… should we do a full-fledged TUI?
+
+**Yes—eventually.**
+But the first milestone should be:
+
+### Milestone 1 (fast, correct): “CLI + interactive REPL”
+
+* Slash commands
+* Todo tracking in files (`TASKS.md` + per-task folders)
+* Job registry (`.lily/runs/`)
+* Validation gates
+
+### Milestone 2 (power): “Real TUI shell”
+
+* Kanban board view
+* Agent tabs
+* Logs view
+* Diff/review view
+* Command palette
+
+This path gets you to the full TUI *without betting the project on UI plumbing.*
+

--- a/docs/ideas/docs_site.md
+++ b/docs/ideas/docs_site.md
@@ -1,0 +1,112 @@
+For our Python projects, when we want **Markdown-based documentation that turns into a clean, navigable site**, we almost always reach for one of these—ranked by how well they fit *our* style and workflows:
+
+---
+
+### **1. MkDocs (default choice)**
+
+**This is the one we usually mean.**
+
+**Why it fits us so well**
+
+* Native **Markdown-first**
+* Minimal configuration, fast to stand up
+* Excellent for **architecture docs, ADRs, workflows, and specs**
+* Plays nicely with GitHub Pages
+* Clean sidebar navigation from `mkdocs.yml`
+
+**Typical stack**
+
+```text
+docs/
+  index.md
+  architecture.md
+  design.md
+  roadmap.md
+  api.md
+mkdocs.yml
+```
+
+**Common theme**
+
+* `mkdocs-material` (this is what gives it the polished look)
+
+**Why I favor it**
+
+* No ceremony
+* Docs feel like “living design notes,” not academic papers
+* Perfect for systems like Chrona / Petal / Lily where architecture evolves
+
+---
+
+### **2. MkDocs + Material Theme**
+
+This is technically MkDocs, but it deserves its own callout.
+
+**Adds**
+
+* Versioned docs
+* Search (excellent)
+* Tabs, callouts, diagrams, admonitions
+* Dark mode (important, obviously 😌)
+
+**Bonus**
+
+* Mermaid diagrams work cleanly
+* Great for CLI + TUI documentation
+
+If we say *“real docs site”*, this is usually what we mean.
+
+---
+
+### **3. Sphinx (only when API docs dominate)**
+
+Still Markdown-capable via **MyST**, but…
+
+**We use it when**
+
+* Auto-generated API reference is the primary goal
+* Heavy docstring extraction
+* ReadTheDocs style expectations
+
+**Why it’s not our default**
+
+* Heavier mental overhead
+* More config
+* Feels slower for early-stage system design
+
+I treat Sphinx as **API-first**, not **architecture-first**.
+
+---
+
+### **4. Docusaurus (rare for Python)**
+
+Markdown-based, yes—but…
+
+**Why we usually skip it**
+
+* JS ecosystem overhead
+* Better for product docs than dev architecture
+* Less natural fit for Python repos
+
+---
+
+### **My recommendation (and what we “usually” mean)**
+
+If you asked this instinctively, the answer is:
+
+> **MkDocs + Material + Markdown**
+
+It aligns perfectly with:
+
+* Spec-Kit style thinking
+* Incremental architecture evolution
+* CLI/TUI tool documentation
+* GitHub-native workflows
+
+If you want, I can:
+
+* Scaffold a **drop-in MkDocs setup**
+* Propose a **docs IA** (information architecture)
+* Or align it with the CLI/TUI split we were discussing earlier
+
+Just say the word—I’ll make it neat and opinionated 💜

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+# Lily Documentation
+
+Welcome to the Lily project documentation site.
+
+Lily is a spec-driven orchestration framework where Lily generates structured specifications, plans, and context artifacts, then hands them off to external AI coding agents (Claude, Cursor, etc.). Focused on portability, clarity, and high-quality AI handoffs—without Lily writing code herself.
+
+## Quick Start
+
+1. **Initialize a project**: `lily init <project-name>` or `lily init --here`
+2. **Check status**: `lily status`
+3. **View documentation**: Browse the sections below
+
+## Documentation Sections
+
+- **[Getting Started](getting-started.md)** - Quick start guide for new users
+- **[Architecture](architecture.md)** - System architecture and design
+- **[Commands](commands/index.md)** - CLI command documentation
+- **[Specifications](specs/)** - Feature specifications and implementation plans
+- **[Ideas](ideas/)** - Design ideas, architecture notes, and UX concepts
+- **[Deployment](deployment.md)** - Deploying documentation to GitHub Pages
+
+## Project Overview
+
+Lily helps you:
+
+- Generate structured specifications from natural language
+- Create implementation plans with clear task breakdowns
+- Maintain project context and documentation
+- Orchestrate AI coding agents with high-quality handoffs
+
+## Getting Help
+
+For more information, see the [Quickstart Guide](../specs/002-docs-site-infrastructure/quickstart.md) or browse the documentation sections above.
+

--- a/docs/mermaid-test.md
+++ b/docs/mermaid-test.md
@@ -1,0 +1,46 @@
+# Mermaid Diagram Test
+
+This page tests Mermaid diagram rendering in the documentation site.
+
+## Flowchart Example
+
+```mermaid
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action 1]
+    B -->|No| D[Action 2]
+    C --> E[End]
+    D --> E
+```
+
+## Sequence Diagram Example
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Command
+    participant Storage
+    
+    User->>CLI: lily init
+    CLI->>Command: execute()
+    Command->>Storage: create files
+    Storage-->>Command: success
+    Command-->>CLI: result
+    CLI-->>User: output
+```
+
+## State Diagram Example
+
+```mermaid
+stateDiagram-v2
+    [*] --> DISCOVERY
+    DISCOVERY --> SPEC
+    SPEC --> ARCH
+    ARCH --> IMPLEMENT
+    IMPLEMENT --> POLISH
+    POLISH --> [*]
+```
+
+These diagrams should render correctly if Mermaid plugin is configured properly.
+

--- a/docs/specs/001-init-command/checklists/requirements.md
+++ b/docs/specs/001-init-command/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Init Command
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+

--- a/docs/specs/001-init-command/contracts/command-interface.md
+++ b/docs/specs/001-init-command/contracts/command-interface.md
@@ -1,0 +1,320 @@
+# Command Interface Contract: Init Command
+
+**Date**: 2026-01-14  
+**Feature**: Init Command
+
+## CLI Interface
+
+### Command Signature
+
+```bash
+lily init [PROJECT_NAME] [--here]
+```
+
+**Arguments**:
+- `PROJECT_NAME` (required unless `--here` is specified): Name of the project
+
+**Options**:
+- `--here`: Use current directory name (basename of current working directory) as project name. If `--here` is specified, PROJECT_NAME argument is not required and will be ignored if provided.
+
+**Behavior**:
+- If `--here` is specified: Use current directory name as project name
+- If `--here` is NOT specified: PROJECT_NAME argument is REQUIRED (command fails if missing)
+
+**Exit Codes**:
+- `0`: Success - project initialized
+- `1`: Error - permission denied, invalid path, or other failure
+
+---
+
+## Command Execution Flow
+
+### Input
+- Project name (required string unless `--here` flag is specified)
+- `--here` flag (optional boolean): If specified, use current directory name as project name
+- Current working directory (Path)
+
+### Processing
+1. Validate project name: If `--here` is not specified, PROJECT_NAME is required (fail if missing). If `--here` is specified, derive project name from current directory basename
+2. Validate current directory is writable (FR-012, FR-018)
+3. Check for existing `.lily/` directory
+4. Create directory structure (FR-001, FR-007)
+5. Create system artifacts (FR-003, FR-004, FR-005, FR-006)
+6. Create user-facing artifacts (FR-002, FR-008, FR-009)
+7. Update index.json with all created artifacts
+8. Write log entries to both log.md and log.jsonl (FR-005)
+
+### Output
+- **Success**: Console output listing all created files (FR-013)
+- **Failure**: Clear error message with specific failure reason (FR-018)
+
+---
+
+## Command Result Structure
+
+### Success Result
+
+```python
+class InitResult:
+    success: bool = True
+    project_name: str
+    files_created: List[str]
+    files_skipped: List[str]  # If re-running on existing project
+    state_file: Path  # Path to .lily/state.json
+    message: str  # Human-readable summary
+```
+
+**Example Console Output**:
+```
+✓ Project 'myproject' initialized successfully
+
+Created files:
+  docs/VISION.md
+  docs/GOALS.md
+  docs/NON_GOALS.md
+  docs/CONSTRAINTS.md
+  docs/ASSUMPTIONS.md
+  docs/OPEN_QUESTIONS.md
+  docs/README.md
+  .lily/state.json
+  .lily/index.json
+  .lily/log.md
+  .lily/log.jsonl
+  .lily/config.json
+
+Project is ready for the next phase (DISCOVERY).
+```
+
+### Error Result
+
+```python
+class InitError:
+    success: bool = False
+    error_type: str  # "permission_denied", "invalid_path", "corrupted_state", etc.
+    message: str  # Human-readable error message
+    failed_paths: List[str]  # Specific paths that failed (for permission errors)
+```
+
+**Example Console Output**:
+```
+✗ Failed to initialize project: Permission denied
+
+Cannot write to the following paths:
+  .lily/state.json
+  docs/VISION.md
+
+Please check write permissions and try again.
+```
+
+---
+
+## Command Pattern Implementation
+
+### Base Command Interface
+
+```python
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Protocol
+
+class CommandResult(Protocol):
+    success: bool
+    message: str
+
+class Command(ABC):
+    @abstractmethod
+    def execute(self, *args, **kwargs) -> CommandResult:
+        """Execute the command and return result."""
+        pass
+    
+    @abstractmethod
+    def validate(self, *args, **kwargs) -> bool:
+        """Validate prerequisites before execution."""
+        pass
+```
+
+### InitCommand Implementation
+
+```python
+class InitCommand(Command):
+    def __init__(self, storage: Storage, logger: Logger):
+        self.storage = storage
+        self.logger = logger
+    
+    def validate(self, project_name: str, root_path: Path) -> bool:
+        """Validate that init can proceed."""
+        # Check write permissions
+        # Check for existing .lily/ (handle corruption if needed)
+        # Validate project name
+        pass
+    
+    def execute(self, project_name: str, root_path: Path) -> InitResult:
+        """Execute init command."""
+        # 1. Validate prerequisites
+        # 2. Create directory structure
+        # 3. Create all artifacts
+        # 4. Update index
+        # 5. Write logs
+        # 6. Return result
+        pass
+```
+
+---
+
+## Storage Interface Contract
+
+### Storage Operations
+
+```python
+class Storage(Protocol):
+    def create_directory(self, path: Path) -> None:
+        """Create directory if it doesn't exist."""
+        pass
+    
+    def create_file(self, path: Path, content: str) -> None:
+        """Create file with content. Skip if exists (idempotent)."""
+        pass
+    
+    def file_exists(self, path: Path) -> bool:
+        """Check if file exists."""
+        pass
+    
+    def read_json(self, path: Path) -> dict:
+        """Read JSON file. Attempt repair if corrupted."""
+        pass
+    
+    def write_json(self, path: Path, data: dict) -> None:
+        """Write JSON file atomically."""
+        pass
+    
+    def append_jsonl(self, path: Path, entry: dict) -> None:
+        """Append JSONL entry to file."""
+        pass
+    
+    def append_markdown_log(self, path: Path, entry: str) -> None:
+        """Append markdown log entry."""
+        pass
+    
+    def calculate_hash(self, path: Path) -> str:
+        """Calculate SHA-256 hash of file content."""
+        pass
+    
+    def check_permissions(self, path: Path) -> bool:
+        """Check if path is writable."""
+        pass
+```
+
+---
+
+## Logger Interface Contract
+
+### Dual-Format Logging
+
+```python
+class Logger(Protocol):
+    def log_init(
+        self,
+        action: str,  # "created", "skipped", "repaired"
+        files: List[str],
+        metadata: dict
+    ) -> None:
+        """Log init command execution to both log.md and log.jsonl."""
+        pass
+```
+
+**Synchronization Requirement**: Both log formats must contain the same information, written atomically.
+
+---
+
+## Error Handling Contract
+
+### Error Types
+
+1. **PermissionError**: Write permission denied
+   - **Behavior**: Fail immediately with clear message (FR-018)
+   - **Message**: List all failed paths
+
+2. **CorruptedStateError**: `.lily/state.json` is corrupted
+   - **Behavior**: Repair by recreating with defaults, log event (FR-017)
+   - **Message**: Inform user of repair action
+
+3. **InvalidPathError**: Project name contains invalid characters
+   - **Behavior**: Fail with validation error
+   - **Message**: Explain valid character requirements
+
+4. **DiskSpaceError**: Insufficient disk space
+   - **Behavior**: Fail with clear error
+   - **Message**: Indicate space requirement
+
+---
+
+## Idempotency Contract
+
+### Re-running Init
+
+When `lily init` is run on an already-initialized project:
+
+1. **Existing Files**: Skip (do not overwrite) - FR-016
+2. **Missing Files**: Create only missing files
+3. **Corrupted Files**: Repair corrupted system files (state.json, index.json, config.json)
+4. **Log Entries**: Append new log entry documenting the re-run
+5. **Result**: Success with list of files created vs. skipped
+
+**Example**:
+```
+✓ Project 'myproject' re-initialized
+
+Created files:
+  docs/ASSUMPTIONS.md  (was missing)
+
+Skipped files (already exist):
+  docs/VISION.md
+  .lily/state.json
+  ... (other existing files)
+```
+
+---
+
+## Validation Contract
+
+### Pre-execution Validation
+
+1. **Path Validation**: 
+   - Current directory exists and is accessible
+   - Project name is valid for filesystem paths
+
+2. **Permission Validation**:
+   - Check write permissions before attempting file creation
+   - Fail fast if permissions insufficient
+
+3. **State Validation**:
+   - If `.lily/state.json` exists, validate schema
+   - If corrupted, repair before proceeding
+
+### Post-execution Validation
+
+1. **File Creation Verification**:
+   - Verify all required files exist
+   - Verify file contents match expected structure
+
+2. **State Consistency**:
+   - Verify state.json is valid
+   - Verify index.json contains all created artifacts
+   - Verify logs are synchronized
+
+---
+
+## Performance Contract
+
+### Timing Requirements
+
+- **SC-001**: Complete initialization in under 5 seconds
+- **Measurement**: From command invocation to result return
+
+### Optimization Strategies
+
+- Batch file operations where possible
+- Use atomic file writes to prevent partial state
+- Validate permissions once before bulk operations
+- Calculate hashes only for files that need indexing
+

--- a/docs/specs/001-init-command/data-model.md
+++ b/docs/specs/001-init-command/data-model.md
@@ -1,0 +1,204 @@
+# Data Model: Init Command
+
+**Date**: 2026-01-14  
+**Feature**: Init Command
+
+## Entities
+
+### 1. Project
+
+**Purpose**: Represents a Lily-managed project with metadata and workflow state.
+
+**Attributes**:
+- `project_name` (string, required): Name of the project
+- `phase` (string, enum, required): Current workflow phase (DISCOVERY, SPEC, ARCH, etc.)
+- `created_at` (datetime, required): Project creation timestamp
+- `last_updated` (datetime, required): Last modification timestamp
+- `version` (string, required): Lily version that created/updated the project
+
+**Storage**: Stored in `.lily/state.json` as JSON. Note: `root_path` is not stored in state.json; it is derived from the filesystem location where the init command is executed.
+
+**Validation Rules**:
+- `project_name` must be non-empty string
+- `phase` must be valid enum value (init sets to "DISCOVERY")
+- `created_at` and `last_updated` must be valid ISO 8601 timestamps
+- `version` must match semantic versioning format
+
+**State Transitions**: 
+- Initial state: `phase = "DISCOVERY"` (set by init command)
+- Future commands will transition phase (out of scope for init)
+
+**Pydantic Model**: `StateModel` in `core/infrastructure/models/state.py`
+
+---
+
+### 2. Artifact
+
+**Purpose**: Represents a file created or managed by Lily.
+
+**Attributes**:
+- `file_path` (string, required): Relative path from project root
+- `artifact_type` (string, enum, required): Either "user-facing" or "system"
+- `last_modified` (datetime, required): Last modification timestamp
+- `hash` (string, required): Content hash (SHA-256) for change detection
+
+**Storage**: Stored in `.lily/index.json` as array of artifact objects
+
+**Validation Rules**:
+- `file_path` must be relative path (not absolute)
+- `artifact_type` must be "user-facing" or "system"
+- `hash` must be valid SHA-256 hex string (64 characters)
+
+**Relationships**:
+- Many artifacts belong to one Project (tracked in index.json)
+
+**Pydantic Model**: `ArtifactModel` in `core/infrastructure/models/index.py`
+
+---
+
+### 3. Log Entry
+
+**Purpose**: Represents an entry in the audit log.
+
+**Attributes**:
+- `timestamp` (datetime, required): ISO 8601 format timestamp
+- `command` (string, required): Command name (e.g., "init")
+- `action` (string, enum, required): Action type: "created", "skipped", "repaired", "failed"
+- `files` (list[string], required): List of file paths affected
+- `metadata` (dict, optional): Additional context (project_name, phase, error messages, etc.)
+
+**Storage**: 
+- `.lily/log.jsonl` - One JSON object per line (JSONL format)
+- `.lily/log.md` - Human-readable markdown format
+
+**Validation Rules**:
+- `timestamp` must be valid ISO 8601 datetime
+- `command` must be non-empty string
+- `action` must be valid enum value
+- `files` must be list of strings (can be empty)
+- Both formats must be kept synchronized
+
+**Pydantic Model**: `LogEntryModel` in `core/infrastructure/models/log.py`
+
+---
+
+### 4. Config
+
+**Purpose**: Project-level Lily configuration.
+
+**Attributes**:
+- `version` (string, required): Config schema version
+- `project_name` (string, required): Project name
+- `created_at` (datetime, required): Config creation timestamp
+
+**Storage**: Stored in `.lily/config.json` as JSON
+
+**Validation Rules**:
+- `version` must match semantic versioning
+- `project_name` must be non-empty string
+- `created_at` must be valid ISO 8601 timestamp
+
+**Future Extensibility**: Structure supports additional keys without breaking existing code
+
+**Pydantic Model**: `ConfigModel` in `core/infrastructure/models/config.py`
+
+---
+
+## Data Relationships
+
+```
+Project (1) ──< (many) Artifact
+Project (1) ──< (many) LogEntry
+Project (1) ──< (1) Config
+```
+
+- One Project has many Artifacts (tracked in index.json)
+- One Project has many Log Entries (tracked in log.jsonl/log.md)
+- One Project has one Config (stored in config.json)
+
+---
+
+## File Structure
+
+### `.lily/state.json`
+```json
+{
+  "phase": "DISCOVERY",
+  "project_name": "myproject",
+  "created_at": "2026-01-14T10:30:00Z",
+  "last_updated": "2026-01-14T10:30:00Z",
+  "version": "0.1.0"
+}
+```
+
+### `.lily/index.json`
+```json
+[
+  {
+    "file_path": "docs/VISION.md",
+    "artifact_type": "user-facing",
+    "last_modified": "2026-01-14T10:30:00Z",
+    "hash": "abc123..."
+  },
+  {
+    "file_path": ".lily/state.json",
+    "artifact_type": "system",
+    "last_modified": "2026-01-14T10:30:00Z",
+    "hash": "def456..."
+  }
+]
+```
+
+### `.lily/log.jsonl`
+```jsonl
+{"timestamp": "2026-01-14T10:30:00Z", "command": "init", "action": "created", "files": ["docs/VISION.md", ".lily/state.json"], "metadata": {"project_name": "myproject", "phase": "DISCOVERY"}}
+```
+
+### `.lily/log.md`
+```markdown
+[2026-01-14 10:30:00] init
+- created: docs/VISION.md
+- created: .lily/state.json
+```
+
+### `.lily/config.json`
+```json
+{
+  "version": "0.1.0",
+  "project_name": "myproject",
+  "created_at": "2026-01-14T10:30:00Z"
+}
+```
+
+---
+
+## Validation Rules Summary
+
+1. **State Validation**: 
+   - Phase must be valid enum
+   - Timestamps must be ISO 8601
+   - All required fields present
+
+2. **Artifact Validation**:
+   - File paths must be relative
+   - Artifact type must be enum value
+   - Hash must be valid SHA-256
+
+3. **Log Entry Validation**:
+   - Timestamp must be ISO 8601
+   - Action must be valid enum
+   - Files list must be array of strings
+
+4. **Config Validation**:
+   - Version must be semantic version
+   - All required fields present
+
+---
+
+## Error Handling
+
+- **Corrupted JSON**: Attempt repair by recreating with defaults (FR-017)
+- **Invalid Schema**: Fail with clear error message indicating which file and what's wrong
+- **Missing Required Fields**: Use defaults where possible, fail if critical field missing
+- **Hash Calculation Failure**: Log error, continue with empty hash (should not happen in normal operation)
+

--- a/docs/specs/001-init-command/plan.md
+++ b/docs/specs/001-init-command/plan.md
@@ -1,0 +1,175 @@
+# Implementation Plan: Init Command
+
+**Branch**: `001-init-command` | **Date**: 2026-01-14 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-init-command/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+The `init` command is the foundational command that bootstraps a new Lily project by creating the required directory structure, system artifacts (state.json, index.json, log files, config.json), and user-facing documentation templates. This command establishes the "command pipeline spine" that all future Lily commands depend on. The implementation will use the Command Pattern for the command itself, filesystem operations for artifact creation, and Pydantic models for structured data validation. The command must be idempotent, deterministic, and handle edge cases like existing files, corrupted state, and permission errors.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (as specified in pyproject.toml)  
+**Primary Dependencies**: 
+- Pydantic >=2.0.0 (for JSON/JSONL model validation)
+- Typer (for CLI framework)
+- pytest >=7.4.0 with pytest-cov (for testing and coverage)
+- Standard library (pathlib, json, datetime) for filesystem and JSON operations
+**Storage**: Filesystem-based (no database required for init command)  
+**Testing**: pytest >=7.4.0 with pytest-cov, test structure: `tests/unit/` and `tests/integration/`
+**Target Platform**: Cross-platform (Linux, macOS, Windows) - command-line tool  
+**Project Type**: Single Python package (CLI application)  
+**Performance Goals**: Init command must complete in under 5 seconds (per SC-001)  
+**Constraints**: 
+- Must be deterministic (same inputs produce same outputs)
+- Must be idempotent (safe to run multiple times)
+- Must not invoke LLMs or generate code
+- Must not require interactive input beyond project name
+- All file operations must be atomic where possible
+**Scale/Scope**: Single project initialization per execution (not batch processing)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Phase 0 ✅ PASSED
+
+**Code Quality:**
+- [x] All code will meet production-quality standards (readable, maintainable, error handling)
+- [x] Code will be properly structured with clear separation of concerns (following architecture: core/application, core/domain, core/infrastructure)
+- [x] Appropriate documentation will be included for complex behavior (Pydantic models, command execution flow)
+
+**Minimal Code Generation:**
+- [x] Implementation plan includes ONLY code required by specification (init command, file creation, state management)
+- [x] No speculative features or "nice-to-have" items included
+- [x] No premature abstractions or "future-proofing" code planned (only what's needed for init)
+- [x] All planned code traces directly to specification requirements (FR-001 through FR-018)
+
+**Gang of Four Patterns:**
+- [x] Design identifies which GoF patterns will be used:
+  - **Command Pattern**: InitCommand class for the command execution (required by architecture)
+  - **Template Method Pattern**: For consistent artifact generation (markdown templates)
+  - **Strategy Pattern**: Not needed for init (no swappable algorithms)
+  - **State Pattern**: Not needed for init (state is just data, not behavior)
+  - **Observer Pattern**: Not needed for init (no event subscriptions required)
+  - **Facade Pattern**: CommandBus/App facade for CLI to call (required by architecture)
+  - **Abstract Factory**: Not needed for init (no adapter families)
+- [x] Pattern selection is justified: Command Pattern required by architecture for all commands; Template Method for consistent file generation
+- [x] Patterns solve concrete problems: Command Pattern enables CLI/TUI reuse; Template Method ensures deterministic artifact structure
+
+**Testability:**
+- [x] Code structure enables unit and integration testing (command class, storage layer, models all testable)
+- [x] Critical paths have corresponding test plans (file creation, idempotency, error handling, corruption repair)
+- [x] Test coverage targets are defined: Minimum 80% for critical paths (per constitution)
+
+### Post-Phase 1 ✅ PASSED
+
+**Re-evaluation after design completion:**
+
+- [x] **Code Quality**: Design maintains production-quality standards with clear separation (application/domain/infrastructure layers)
+- [x] **Minimal Code Generation**: Design includes only required components (models, storage, command, CLI) - no speculative code
+- [x] **GoF Patterns**: Command Pattern and Template Method Pattern properly applied to solve concrete problems
+- [x] **Testability**: Design enables comprehensive testing with unit tests (models, storage, command) and integration tests (end-to-end init flow)
+
+**No violations detected. Design is compliant with constitution.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── lily/
+    ├── __init__.py
+    ├── app.py                    # CLI entry point (future: TUI entry)
+    └── core/
+        ├── __init__.py
+        ├── application/         # Use cases (commands)
+        │   ├── __init__.py
+        │   └── commands/
+        │       ├── __init__.py
+        │       ├── base.py        # Base Command class
+        │       └── init.py       # InitCommand implementation
+        ├── domain/               # Entities + rules
+        │   ├── __init__.py
+        │   ├── project.py         # Project entity
+        │   ├── artifact.py        # Artifact entity
+        │   └── state.py           # State entity
+        └── infrastructure/        # Filesystem, storage
+            ├── __init__.py
+            ├── storage.py        # Filesystem operations
+            └── models/            # Pydantic models
+                ├── __init__.py
+                ├── state.py       # State JSON model
+                ├── index.py       # Index JSON model
+                ├── config.py      # Config JSON model
+                └── log.py         # Log entry JSONL model
+    └── ui/
+        └── cli/
+            ├── __init__.py
+            └── main.py            # CLI command registration (Typer/Click)
+
+tests/
+├── unit/
+│   ├── test_init_command.py
+│   ├── test_storage.py
+│   └── test_models.py
+└── integration/
+    └── test_init_integration.py
+```
+
+**Structure Decision**: Following the two-layer architecture from `ideas/core/two_layer.md`, the code is organized into:
+- `core/application/commands/` - Command Pattern implementations (InitCommand)
+- `core/domain/` - Domain entities (Project, Artifact, State)
+- `core/infrastructure/` - Filesystem operations and Pydantic models
+- `ui/cli/` - CLI interface (will be extended to TUI later without changing core)
+
+## Phase Completion Status
+
+### Phase 0: Research ✅ Complete
+
+**Output**: [research.md](./research.md)
+
+**Resolved**:
+- Pydantic version: v2 (>=2.0.0)
+- CLI framework: Typer
+- Testing framework: pytest >=7.4.0 with pytest-cov
+- Log formats: JSONL and Markdown structures defined
+- Config structure: Minimal extensible structure
+
+### Phase 1: Design & Contracts ✅ Complete
+
+**Outputs**:
+- [data-model.md](./data-model.md) - Entity definitions, relationships, validation rules
+- [contracts/command-interface.md](./contracts/command-interface.md) - CLI interface, command pattern, storage contracts
+- [quickstart.md](./quickstart.md) - Implementation guide and testing strategy
+
+**Design Artifacts**:
+- Data models defined with Pydantic schemas
+- Command interface contract established
+- Storage layer interface defined
+- Logging dual-format structure specified
+- Error handling contracts defined
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/docs/specs/001-init-command/quickstart.md
+++ b/docs/specs/001-init-command/quickstart.md
@@ -1,0 +1,289 @@
+# Quick Start: Implementing Init Command
+
+**Date**: 2026-01-14  
+**Feature**: Init Command
+
+## Overview
+
+This guide provides a step-by-step approach to implementing the `init` command, the foundational command that bootstraps a Lily project.
+
+## Prerequisites
+
+1. Python 3.13 installed
+2. `uv` package manager installed ([install uv](https://github.com/astral-sh/uv))
+3. Install runtime dependencies:
+   ```bash
+   uv add pydantic typer
+   ```
+   (uv will automatically determine the best compatible versions)
+
+4. Install development dependencies:
+   ```bash
+   uv add --dev pytest pytest-cov mypy
+   ```
+   (uv will automatically determine the best compatible versions)
+
+5. Or install all dependencies at once:
+   ```bash
+   uv sync
+   ```
+   (reads from `pyproject.toml` and installs both runtime and dev dependencies)
+
+## Implementation Order
+
+### Step 1: Set Up Project Structure
+
+Create the directory structure following the architecture:
+
+```bash
+mkdir -p src/lily/core/{application/commands,domain,infrastructure/models}
+mkdir -p src/lily/ui/cli
+mkdir -p tests/{unit,integration}
+```
+
+### Step 2: Implement Pydantic Models
+
+Start with data models (foundation for everything else):
+
+1. **State Model** (`core/infrastructure/models/state.py`):
+   - Define `StateModel` with fields: phase, project_name, created_at, last_updated, version
+   - Add validation for phase enum
+   - Add JSON serialization/deserialization
+
+2. **Artifact Model** (`core/infrastructure/models/index.py`):
+   - Define `ArtifactModel` with fields: file_path, artifact_type, last_modified, hash
+   - Add validation for artifact_type enum
+   - Define `IndexModel` as list of ArtifactModel
+
+3. **Config Model** (`core/infrastructure/models/config.py`):
+   - Define `ConfigModel` with fields: version, project_name, created_at
+   - Minimal structure, extensible
+
+4. **Log Entry Model** (`core/infrastructure/models/log.py`):
+   - Define `LogEntryModel` with fields: timestamp, command, action, files, metadata
+   - Add validation for action enum
+   - Add JSONL serialization method
+
+### Step 3: Implement Storage Layer
+
+Create filesystem operations (`core/infrastructure/storage.py`):
+
+1. **Basic Operations**:
+   - `create_directory()` - Create directory if not exists
+   - `create_file()` - Create file with content (skip if exists)
+   - `file_exists()` - Check file existence
+   - `check_permissions()` - Validate write permissions
+
+2. **JSON Operations**:
+   - `read_json()` - Read JSON with corruption repair
+   - `write_json()` - Atomic JSON write
+   - `calculate_hash()` - SHA-256 hash calculation
+
+3. **Log Operations**:
+   - `append_jsonl()` - Append to JSONL file
+   - `append_markdown_log()` - Append to markdown log
+   - `sync_logs()` - Keep both formats synchronized
+
+### Step 4: Implement Domain Entities
+
+Create domain models (`core/domain/`):
+
+1. **Project Entity** (`domain/project.py`):
+   - Represents a Lily project
+   - Loads/saves from state.json
+   - Handles phase transitions (future)
+
+2. **Artifact Entity** (`domain/artifact.py`):
+   - Represents a file artifact
+   - Calculates and stores hash
+   - Tracks modification time
+
+3. **State Entity** (`domain/state.py`):
+   - Manages workflow state
+   - Validates state transitions
+   - Handles corruption repair
+
+### Step 5: Implement Command Pattern
+
+Create command infrastructure:
+
+1. **Base Command** (`core/application/commands/base.py`):
+   - Abstract `Command` class
+   - `execute()` and `validate()` methods
+   - `CommandResult` protocol
+
+2. **Init Command** (`core/application/commands/init.py`):
+   - Implement `InitCommand` class
+   - Implement `validate()` - check permissions, validate paths
+   - Implement `execute()` - orchestrate file creation
+   - Handle idempotency (skip existing files)
+   - Handle corruption repair
+   - Return `InitResult`
+
+### Step 6: Implement Artifact Templates
+
+Create template generators for markdown files:
+
+1. **Template Method Pattern**:
+   - Base `ArtifactGenerator` class
+   - Concrete generators: `VisionGenerator`, `GoalsGenerator`, etc.
+   - Each generator creates file with proper structure
+
+2. **Template Content**:
+   - Section headers
+   - Guidance comments
+   - Empty bullet lists
+   - Consistent formatting
+
+### Step 7: Implement CLI Interface
+
+Create CLI entry point (`ui/cli/main.py`):
+
+1. **Typer Setup**:
+   - Register `init` command
+   - Parse project name argument
+   - Handle command execution
+
+2. **Result Rendering**:
+   - Format success output (list created files)
+   - Format error output (clear error messages)
+   - Exit codes (0 for success, 1 for error)
+
+### Step 8: Implement Logging
+
+Create dual-format logger:
+
+1. **Logger Implementation**:
+   - Write to both `.lily/log.md` and `.lily/log.jsonl`
+   - Keep formats synchronized
+   - Handle log entry creation
+
+2. **Log Entry Creation**:
+   - Create entries for: file creation, skipping, repair, errors
+   - Include metadata (project_name, phase, etc.)
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Model Tests** (`tests/unit/test_models.py`):
+   - Test Pydantic model validation
+   - Test serialization/deserialization
+   - Test enum validation
+
+2. **Storage Tests** (`tests/unit/test_storage.py`):
+   - Test file operations (create, read, write)
+   - Test permission checking
+   - Test hash calculation
+   - Test corruption repair
+
+3. **Command Tests** (`tests/unit/test_init_command.py`):
+   - Test command validation
+   - Test idempotency
+   - Test error handling
+   - Mock storage layer
+
+### Integration Tests
+
+1. **End-to-End Tests** (`tests/integration/test_init_integration.py`):
+   - Test full init flow in temporary directory
+   - Test file creation
+   - Test state persistence
+   - Test log synchronization
+   - Test re-running init
+
+### Running Tests
+
+Run tests using `uv`:
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run with coverage
+uv run pytest --cov=src/lily --cov-report=html
+
+# Run specific test file
+uv run pytest tests/unit/test_models.py
+
+# Run integration tests only
+uv run pytest tests/integration/
+```
+
+### Type Checking
+
+Run type checking with mypy:
+
+```bash
+# Type check the entire codebase
+uv run mypy src/lily
+
+# Type check with strict mode
+uv run mypy --strict src/lily
+
+# Type check specific module
+uv run mypy src/lily/core/infrastructure/models
+```
+
+## Key Implementation Notes
+
+### Idempotency
+
+- Always check `file_exists()` before creating
+- Skip existing files (don't overwrite)
+- Only create missing files
+- Update logs even when skipping files
+
+### Error Handling
+
+- Validate permissions BEFORE attempting file operations
+- Fail fast with clear error messages
+- Repair corrupted state.json automatically
+- Log all errors to both log formats
+
+### Determinism
+
+- Use fixed timestamps for testing (or mock datetime)
+- Use deterministic file content (templates)
+- No random values in file creation
+- Same inputs → same outputs
+
+### Performance
+
+- Batch file operations where possible
+- Validate permissions once before bulk operations
+- Use atomic writes to prevent partial state
+- Target: <5 seconds for full initialization
+
+## Validation Checklist
+
+Before considering implementation complete:
+
+- [ ] All Pydantic models validate correctly
+- [ ] Storage layer handles all file operations
+- [ ] Init command creates all required files
+- [ ] Idempotency works (re-run doesn't break)
+- [ ] Corruption repair works
+- [ ] Permission errors handled correctly
+- [ ] Logs are synchronized (markdown + JSONL)
+- [ ] Console output is clear and informative
+- [ ] All tests pass (unit + integration)
+- [ ] Test coverage >= 80% for critical paths
+- [ ] Performance meets <5 second target
+
+## Next Steps
+
+After init command is complete:
+
+1. Implement `status` command (reads state.json and index.json)
+2. Implement command bus infrastructure
+3. Add TUI support (reuse same command)
+
+## Resources
+
+- **Specification**: [spec.md](./spec.md)
+- **Data Model**: [data-model.md](./data-model.md)
+- **Contracts**: [contracts/command-interface.md](./contracts/command-interface.md)
+- **Research**: [research.md](./research.md)
+- **Architecture**: `ideas/core/two_layer.md` and `ideas/core/architecture.md`
+

--- a/docs/specs/001-init-command/research.md
+++ b/docs/specs/001-init-command/research.md
@@ -1,0 +1,169 @@
+# Research: Init Command Implementation
+
+**Date**: 2026-01-14  
+**Feature**: Init Command  
+**Purpose**: Resolve technical decisions and clarify implementation choices
+
+## Research Questions
+
+### 1. Pydantic Version Selection
+
+**Question**: What version of Pydantic should be used for JSON/JSONL model validation?
+
+**Research**:
+- Pydantic v2 is the current stable version (released 2023)
+- Pydantic v1 is deprecated but still maintained for legacy projects
+- Pydantic v2 offers better performance, improved validation, and better type hints support
+- Python 3.13 is fully supported by Pydantic v2
+
+**Decision**: Use Pydantic v2 (latest stable version, >=2.0.0)
+
+**Rationale**: 
+- Modern Python 3.13 project should use modern Pydantic
+- Better performance and type safety
+- Active development and community support
+- Required for JSONL parsing with Pydantic models
+
+**Alternatives Considered**:
+- Pydantic v1: Rejected - deprecated, no new features
+- Manual JSON validation: Rejected - Pydantic provides type safety and validation
+
+---
+
+### 2. CLI Framework Selection: Typer vs Click
+
+**Question**: Which CLI framework should be used: Typer or Click?
+
+**Research**:
+- **Typer**: Built on Click, uses type hints, modern Python-first approach, automatic help generation
+- **Click**: Mature, battle-tested, more verbose but explicit, widely used
+- Both support command registration, argument parsing, help text
+- Typer requires Python 3.6+, Click supports older Python versions
+- Typer provides better type safety through type hints
+
+**Decision**: Use Typer
+
+**Rationale**:
+- Modern Python 3.13 project benefits from type-hint-based CLI
+- Cleaner, more Pythonic API
+- Automatic help generation reduces boilerplate
+- Built on Click (proven foundation) but with modern interface
+- Better integration with Pydantic models (both use type hints)
+
+**Alternatives Considered**:
+- Click: Rejected - more verbose, less type-safe, older API style
+- argparse: Rejected - too low-level, requires more boilerplate
+- Custom CLI: Rejected - reinventing the wheel, maintenance burden
+
+---
+
+### 3. Testing Framework and Structure
+
+**Question**: What pytest version and test structure should be used?
+
+**Research**:
+- pytest 7.x is current stable (7.4+ recommended for Python 3.13)
+- pytest supports modern Python features and type hints
+- Standard test structure: `tests/unit/` and `tests/integration/`
+- pytest fixtures for test setup/teardown
+- pytest-cov for coverage reporting (required for 80% coverage target)
+
+**Decision**: 
+- Use pytest >=7.4.0
+- Use pytest-cov for coverage reporting
+- Structure: `tests/unit/` for unit tests, `tests/integration/` for integration tests
+- Use pytest fixtures for temporary directories and test data
+
+**Rationale**:
+- pytest 7.4+ fully supports Python 3.13
+- Standard Python testing framework, widely adopted
+- Good fixture system for filesystem testing (temporary directories)
+- Coverage reporting built-in with pytest-cov
+- Matches Python community best practices
+
+**Alternatives Considered**:
+- unittest: Rejected - more verbose, less modern features
+- nose2: Rejected - less active development, pytest is standard
+- Custom test runner: Rejected - unnecessary complexity
+
+---
+
+## Additional Technical Decisions
+
+### 4. JSONL Log Format Structure
+
+**Question**: What exact structure should JSONL log entries have?
+
+**Decision**: Each line is a JSON object with:
+```json
+{
+  "timestamp": "ISO 8601 format (YYYY-MM-DDTHH:MM:SS)",
+  "command": "init",
+  "action": "created|skipped|repaired|failed",
+  "files": ["path/to/file1", "path/to/file2"],
+  "metadata": {
+    "project_name": "myproject",
+    "phase": "DISCOVERY"
+  }
+}
+```
+
+**Rationale**: 
+- Structured format enables Pydantic model validation
+- Includes all necessary audit information
+- Extensible metadata field for future additions
+- Matches requirements for dual-format logging
+
+---
+
+### 5. Markdown Log Format Structure
+
+**Question**: What exact format should markdown log entries have?
+
+**Decision**: Human-readable format:
+```markdown
+[YYYY-MM-DD HH:MM:SS] init
+- created: docs/VISION.md
+- created: .lily/state.json
+- skipped: docs/GOALS.md (already exists)
+```
+
+**Rationale**:
+- Human-readable for quick inspection
+- Simple format that's easy to parse visually
+- Synchronized with JSONL format (same information, different presentation)
+
+---
+
+### 6. Default Config.json Structure
+
+**Question**: What default keys should config.json contain?
+
+**Decision**: Minimal initial structure:
+```json
+{
+  "version": "0.1.0",
+  "project_name": "myproject",
+  "created_at": "ISO 8601 timestamp"
+}
+```
+
+**Rationale**:
+- Minimal as per specification (FR-006 says "default configuration keys")
+- Extensible structure for future configuration
+- Matches state.json structure for consistency
+- No assumptions about future needs (YAGNI principle)
+
+---
+
+## Summary
+
+All technical decisions have been made:
+- **Pydantic**: v2 (>=2.0.0)
+- **CLI Framework**: Typer
+- **Testing**: pytest >=7.4.0 with pytest-cov
+- **Log Formats**: JSONL (structured) and Markdown (human-readable) with defined schemas
+- **Config**: Minimal structure, extensible
+
+All NEEDS CLARIFICATION items from Technical Context have been resolved.
+

--- a/docs/specs/001-init-command/spec.md
+++ b/docs/specs/001-init-command/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: Init Command
+
+**Feature Branch**: `001-init-command`  
+**Created**: 2026-01-14  
+**Status**: Draft  
+**Input**: User description: "we will work on @ideas/commands/command_init.md"
+
+## Clarifications
+
+### Session 2026-01-14
+
+- Q: When `lily init` is run, how should the project name be determined? → A: Project name is required unless `--here` flag is specified. If `--here` is provided, use current directory name (basename of current working directory) as project name. If `--here` is not specified, PROJECT_NAME argument is required.
+- Q: When `lily init` encounters existing files, what should the system do? → A: Skip existing files, only create missing ones
+- Q: When `lily init` encounters a corrupted `.lily/state.json` file, what should happen? → A: Attempt repair by recreating with defaults and logging the corruption issue in the audit log
+- Q: What are the minimum required fields/structure for each JSON file created by init? → A: Minimal schemas: state.json needs phase, project_name, created_at, last_updated, version; index.json needs array structure for artifacts; config.json needs default configuration keys
+- Q: When `lily init` fails due to insufficient write permissions, what should the system do? → A: Fail immediately with clear error message indicating permission issue and which paths failed
+- Q: What format should log entries follow? → A: Both `.lily/log.md` (human-readable markdown) and `.lily/log.jsonl` (JSONL format for programmatic use with Pydantic models)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Initialize New Project (Priority: P1)
+
+A user wants to bootstrap a new project using Lily's orchestration framework. They run the `init` command to establish the project structure, workspace directories, and initial state files that all subsequent Lily commands will depend on.
+
+**Why this priority**: This is the foundational command that establishes the entire project structure and state management system. Without it, no other Lily commands can function. It's the entry point for all Lily workflows.
+
+**Independent Test**: Can be fully tested by running `lily init <project_name>` in an empty or new directory and verifying all required files and directories are created with correct structure and content. This delivers immediate value by establishing a working project foundation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is in a directory where they want to initialize a Lily project, **When** they run `lily init myproject`, **Then** all required user-facing artifacts (VISION.md, GOALS.md, NON_GOALS.md, CONSTRAINTS.md, ASSUMPTIONS.md, OPEN_QUESTIONS.md) are created in a `docs/` directory with proper structure and guidance templates
+2. **Given** a user runs `lily init myproject`, **When** the command completes successfully, **Then** all system artifacts (`.lily/state.json`, `.lily/index.json`, `.lily/log.md`, `.lily/log.jsonl`, `.lily/config.json`) are created with correct initial values
+3. **Given** a user runs `lily init myproject`, **When** the command completes, **Then** the required directory structure (`.lily/runs/`, `.lily/tasks/`) exists with placeholder files
+4. **Given** a user runs `lily init myproject` twice in the same directory, **When** the second execution completes, **Then** no files are corrupted, state remains consistent, and the operation completes without errors (idempotent behavior)
+5. **Given** a user runs `lily init myproject`, **When** the command completes, **Then** the console displays a clear summary listing all files created and the project is ready for the next phase
+
+---
+
+### User Story 2 - Re-initialize Existing Project (Priority: P2)
+
+A user wants to re-run the `init` command on an already-initialized project, either to repair corrupted files or to ensure all required artifacts exist.
+
+**Why this priority**: While not the primary use case, idempotent behavior is critical for reliability and user confidence. Users should be able to safely re-run init without breaking their project.
+
+**Independent Test**: Can be fully tested by running `lily init myproject` (or `lily init --here`) on a directory that already contains some or all of the expected artifacts, and verifying that existing files are preserved or updated appropriately without corruption.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project directory already contains `.lily/state.json` with phase "DISCOVERY", **When** the user runs `lily init myproject` (or `lily init --here`), **Then** the existing state is preserved and no duplicate or conflicting files are created
+2. **Given** a project directory is missing some required artifacts (e.g., `docs/ASSUMPTIONS.md`), **When** the user runs `lily init myproject` (or `lily init --here`), **Then** only the missing artifacts are created, existing files are skipped and left unchanged
+3. **Given** a project directory has a corrupted `.lily/state.json`, **When** the user runs `lily init myproject` (or `lily init --here`), **Then** the system recreates the state file with default values and logs the corruption event in both `.lily/log.md` and `.lily/log.jsonl` for audit trail
+4. **Given** a user runs `lily init myproject` (or `lily init --here`) in a directory where they lack write permissions, **When** the command attempts to create files, **Then** the system fails immediately with a clear error message indicating the permission issue and which specific paths failed
+
+---
+
+### Edge Cases
+
+- What happens when the user doesn't have write permissions in the current directory? → System fails immediately with clear error message indicating permission issue and which paths failed
+- How does the system handle existing files that conflict with Lily's structure (e.g., existing `docs/` directory with different content)? → System skips existing files and only creates missing ones
+- What happens when disk space is insufficient during file creation? → System fails with clear error message indicating insufficient disk space. Partial file creation is acceptable (some files may be created before failure, but state.json should not be created if critical files fail)
+- How does the system behave if `.lily/` directory already exists but is not a valid Lily workspace? → System attempts repair by recreating corrupted files with defaults and logs the issue
+- What happens when the project name contains invalid characters for filesystem paths? → System validates project name before proceeding and fails with clear error message indicating invalid characters. Valid characters: alphanumeric, hyphens, underscores. Invalid: path separators (/ or \), null bytes, control characters
+- How does the system handle running `init` in a directory that is already a git repository vs. a new directory? → System behavior is identical regardless of git repository presence. Init does not interact with git (git is out of scope for init command)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST create a `.lily/` directory structure containing all required system artifacts (state.json, index.json, log.md, log.jsonl, config.json, runs/, tasks/)
+- **FR-002**: System MUST create a `docs/` directory containing all required user-facing artifacts (VISION.md, GOALS.md, NON_GOALS.md, CONSTRAINTS.md, ASSUMPTIONS.md, OPEN_QUESTIONS.md)
+- **FR-003**: System MUST create `.lily/state.json` with initial phase set to "DISCOVERY" and project metadata. Minimum required fields: `phase` (string, value "DISCOVERY"), `project_name` (string), `created_at` (ISO 8601 datetime), `last_updated` (ISO 8601 datetime), `version` (string). Note: `root_path` is not stored in state.json; it is derived from the filesystem location where init is executed.
+- **FR-004**: System MUST create `.lily/index.json` to track artifact metadata. Structure must be an array where each entry contains: file path (string), artifact type (string: "user-facing" or "system"), last modified (ISO 8601 datetime), hash (string)
+- **FR-005**: System MUST create both `.lily/log.md` (human-readable markdown format) and `.lily/log.jsonl` (JSONL format for programmatic use) as append-only audit logs. Both logs MUST contain an initial entry documenting the init command execution, with entries synchronized between both formats
+- **FR-006**: System MUST create `.lily/config.json` with default project-level configuration values. Structure must contain: `version` (string, semantic version), `project_name` (string), `created_at` (ISO 8601 datetime). See data-model.md for complete schema definition. Structure must support extensibility for future keys.
+- **FR-007**: System MUST create directory structure for `.lily/runs/` and `.lily/tasks/` with placeholder files to ensure directories exist
+- **FR-008**: System MUST create all user-facing markdown files with proper structure including section headers, guidance comments, and empty bullet lists ready for content
+- **FR-009**: System MUST create `docs/README.md` explaining the purpose of the docs folder and how Lily uses it
+- **FR-010**: System MUST ensure all file creation is deterministic (same inputs produce same outputs - file content is identical across runs with same project name)
+- **FR-011**: System MUST support idempotent execution (running init multiple times does not corrupt state or create duplicate files - safe to re-run)
+- **FR-016**: System MUST skip existing files when re-running init, only creating files that are missing (preserves user work while ensuring completeness)
+- **FR-017**: System MUST attempt to repair corrupted `.lily/state.json` files by recreating them with default values and MUST log the corruption event in both `.lily/log.md` and `.lily/log.jsonl` for audit trail
+- **FR-018**: System MUST fail immediately with a clear error message when write permissions are insufficient, indicating the permission issue and which specific paths failed
+- **FR-012**: System MUST validate that required paths can be created before proceeding with file creation
+- **FR-013**: System MUST provide clear console output listing all files created during initialization
+- **FR-014**: System MUST NOT generate any code, invoke any LLM, ask architecture questions, or assume specific programming languages or frameworks during initialization
+- **FR-015**: System MUST ensure the created state and structure are compatible with future commands (status, spec, arch, etc.) without requiring changes to the init output format
+
+### Key Entities *(include if feature involves data)*
+
+- **Project**: Represents a Lily-managed project with a name and workflow phase. Key attributes include project_name, created_at timestamp, and current phase state. The root path is derived from the filesystem location where init is executed, not stored in state.json.
+- **Artifact**: Represents a file created or managed by Lily. Key attributes include file path, artifact type (user-facing vs system), last modified timestamp, and content hash for change detection. Artifacts are tracked in `.lily/index.json` as an array structure, where each entry contains: file path, artifact type, last modified timestamp, and hash
+- **State**: Represents the workflow state machine state stored in `.lily/state.json`. Key attributes include phase (DISCOVERY, SPEC, ARCH, etc.), project metadata, and version information. Minimum required fields: `phase` (string), `project_name` (string), `created_at` (timestamp), `last_updated` (timestamp), `version` (string)
+- **Log Entry**: Represents an entry in the append-only audit log. Logs are maintained in dual format: `.lily/log.md` (human-readable markdown) and `.lily/log.jsonl` (JSONL format for programmatic parsing with Pydantic models). Key attributes include timestamp, command executed, and list of files created or modified. Both formats must be kept synchronized
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can successfully initialize a new Lily project in under 5 seconds from command execution to completion
+- **SC-002**: 100% of required artifacts are created deterministically on every successful init execution: 6 user-facing markdown files (VISION.md, GOALS.md, NON_GOALS.md, CONSTRAINTS.md, ASSUMPTIONS.md, OPEN_QUESTIONS.md), 5 system files (state.json, index.json, config.json, log.md, log.jsonl), 1 docs directory README (docs/README.md), and 2 directory structures (.lily/runs/, .lily/tasks/) with placeholder files
+- **SC-003**: Users can re-run `lily init` on the same project directory without errors or state corruption (100% idempotency success rate)
+- **SC-004**: The initialized project structure enables the `status` command to successfully read and display phase information and artifact presence without modification to init output format
+- **SC-005**: All created artifacts contain proper structure (section headers, guidance comments, empty lists) that are immediately usable for content entry by users or AI coders
+- **SC-006**: Console output clearly communicates all created files and directories, enabling users to verify successful initialization without manual file system inspection
+
+## Assumptions
+
+- Users have write permissions in the directory where they run `lily init`
+- The filesystem supports standard directory and file creation operations
+- Project names provided by users are valid for filesystem paths (no special characters that would cause path issues)
+- Users understand that `.lily/` is a system directory that should not be manually edited
+- The initialized project will be used within a version control system (git), but init does not require git to be initialized
+- Future commands (status, spec, arch, etc.) will read from the structure created by init without requiring format changes
+
+## Dependencies
+
+- Storage layer (filesystem operations) must be implemented before init command
+- Command bus and result object infrastructure must exist to support command execution
+- Basic validation framework for path creation and file writing
+
+## Constraints
+
+- Init command must NOT generate any code or invoke LLMs
+- Init command must NOT make assumptions about programming languages or frameworks
+- Init command must NOT ask interactive questions or require user input beyond project name
+- All artifacts must be created deterministically (no random or time-dependent content that changes between runs)
+- System artifacts under `.lily/` must never be manually edited by users
+- The structure created by init must remain stable and not require changes when future features (TUI, multiple AI devs, spec generation) are added

--- a/docs/specs/001-init-command/tasks.md
+++ b/docs/specs/001-init-command/tasks.md
@@ -1,0 +1,238 @@
+# Tasks: Init Command
+
+**Input**: Design documents from `/specs/001-init-command/`
+**Prerequisites**: plan.md, spec.md, data-model.md, contracts/, research.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., [US1], [US2])
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [X] T001 Create project directory structure per implementation plan (src/lily/core/application/commands/, src/lily/core/domain/, src/lily/core/infrastructure/models/, src/lily/ui/cli/, tests/unit/, tests/integration/)
+- [X] T002 [P] Create __init__.py files in all package directories (src/lily/__init__.py, src/lily/core/__init__.py, src/lily/core/application/__init__.py, src/lily/core/application/commands/__init__.py, src/lily/core/domain/__init__.py, src/lily/core/infrastructure/__init__.py, src/lily/core/infrastructure/models/__init__.py, src/lily/ui/__init__.py, src/lily/ui/cli/__init__.py)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T003 [P] Create StateModel Pydantic model in src/lily/core/infrastructure/models/state.py with fields: phase (str, enum), project_name (str), created_at (datetime), last_updated (datetime), version (str)
+- [X] T004 [P] Create ArtifactModel Pydantic model in src/lily/core/infrastructure/models/index.py with fields: file_path (str), artifact_type (str, enum: "user-facing" or "system"), last_modified (datetime), hash (str)
+- [X] T005 [P] Create IndexModel Pydantic model in src/lily/core/infrastructure/models/index.py as list of ArtifactModel
+- [X] T006 [P] Create ConfigModel Pydantic model in src/lily/core/infrastructure/models/config.py with fields: version (str), project_name (str), created_at (datetime)
+- [X] T007 [P] Create LogEntryModel Pydantic model in src/lily/core/infrastructure/models/log.py with fields: timestamp (datetime), command (str), action (str, enum: "created", "skipped", "repaired", "failed"), files (list[str]), metadata (dict, optional)
+- [X] T008 Create Storage class in src/lily/core/infrastructure/storage.py implementing file operations: create_directory(), create_file(), file_exists(), check_permissions(), read_json(), write_json(), append_jsonl(), append_markdown_log(), calculate_hash()
+- [X] T009 Create Logger class in src/lily/core/infrastructure/storage.py implementing dual-format logging: log_init() method that writes to both log.md and log.jsonl synchronously
+- [X] T010 Create base Command abstract class in src/lily/core/application/commands/base.py with execute() and validate() abstract methods, and CommandResult protocol
+- [X] T011 Create CommandResult dataclass in src/lily/core/application/commands/base.py with fields: success (bool), message (str), files_created (list[str]), files_skipped (list[str])
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Initialize New Project (Priority: P1) 🎯 MVP
+
+**Goal**: A user wants to bootstrap a new project using Lily's orchestration framework. They run the `init` command to establish the project structure, workspace directories, and initial state files that all subsequent Lily commands will depend on.
+
+**Independent Test**: Can be fully tested by running `lily init <project_name>` in an empty or new directory and verifying all required files and directories are created with correct structure and content. This delivers immediate value by establishing a working project foundation.
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Create InitCommand class in src/lily/core/application/commands/init.py implementing Command interface with validate() and execute() methods
+- [X] T013 [US1] Implement validate() method in InitCommand (src/lily/core/application/commands/init.py) to check write permissions and validate project name
+- [X] T014 [US1] Implement directory creation logic in InitCommand.execute() (src/lily/core/application/commands/init.py) to create .lily/, .lily/runs/, .lily/tasks/, and docs/ directories
+- [X] T015 [US1] Implement system artifact creation in InitCommand.execute() (src/lily/core/application/commands/init.py): create .lily/state.json with StateModel (phase="DISCOVERY", project_name, created_at, last_updated, version)
+- [X] T016 [US1] Implement system artifact creation in InitCommand.execute() (src/lily/core/application/commands/init.py): create .lily/config.json with ConfigModel (version, project_name, created_at)
+- [X] T017 [US1] Implement system artifact creation in InitCommand.execute() (src/lily/core/application/commands/init.py): create .lily/index.json as empty array (IndexModel)
+- [X] T018 [US1] Implement placeholder file creation in InitCommand.execute() (src/lily/core/application/commands/init.py): create .gitkeep files in .lily/runs/ and .lily/tasks/ directories
+- [X] T019 [US1] Create ArtifactGenerator base class in src/lily/core/infrastructure/storage.py using Template Method pattern for consistent markdown file generation
+- [X] T020 [US1] Implement VisionGenerator in src/lily/core/infrastructure/storage.py to create docs/VISION.md with section headers, guidance comments, and empty bullet lists
+- [X] T021 [US1] Implement GoalsGenerator in src/lily/core/infrastructure/storage.py to create docs/GOALS.md with section headers, guidance comments, and empty bullet lists
+- [X] T022 [US1] Implement NonGoalsGenerator in src/lily/core/infrastructure/storage.py to create docs/NON_GOALS.md with section headers, guidance comments, and empty bullet lists
+- [X] T023 [US1] Implement ConstraintsGenerator in src/lily/core/infrastructure/storage.py to create docs/CONSTRAINTS.md with section headers, guidance comments, and empty bullet lists
+- [X] T024 [US1] Implement AssumptionsGenerator in src/lily/core/infrastructure/storage.py to create docs/ASSUMPTIONS.md with section headers, guidance comments, and empty bullet lists
+- [X] T025 [US1] Implement OpenQuestionsGenerator in src/lily/core/infrastructure/storage.py to create docs/OPEN_QUESTIONS.md with section headers, guidance comments, and empty bullet lists
+- [X] T026 [US1] Implement DocsReadmeGenerator in src/lily/core/infrastructure/storage.py to create docs/README.md explaining the purpose of the docs folder
+- [X] T027 [US1] Implement user-facing artifact creation in InitCommand.execute() (src/lily/core/application/commands/init.py): create all 6 markdown files and docs/README.md using generators
+- [X] T028 [US1] Implement index.json update logic in InitCommand.execute() (src/lily/core/application/commands/init.py): add all created artifacts to index.json with file_path, artifact_type, last_modified, and hash
+- [X] T029 [US1] Implement dual-format log entry creation in InitCommand.execute() (src/lily/core/application/commands/init.py): write initial log entry to both .lily/log.md and .lily/log.jsonl using Logger
+- [X] T030 [US1] Implement console output formatting in InitCommand.execute() (src/lily/core/application/commands/init.py): return InitResult with clear summary listing all files created
+- [X] T031 [US1] Create CLI entry point in src/lily/ui/cli/main.py using Typer to register `init` command that calls InitCommand
+- [X] T032 [US1] Implement CLI argument parsing in src/lily/ui/cli/main.py: accept required PROJECT_NAME argument OR --here flag. If --here is specified, use current directory name as project name. If --here is not specified, PROJECT_NAME is required.
+- [X] T033 [US1] Implement CLI result rendering in src/lily/ui/cli/main.py: format InitResult for console output with success message and file list
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently. Running `lily init myproject` should create all required files and directories.
+
+---
+
+## Phase 4: User Story 2 - Re-initialize Existing Project (Priority: P2)
+
+**Goal**: A user wants to re-run the `init` command on an already-initialized project, either to repair corrupted files or to ensure all required artifacts exist.
+
+**Independent Test**: Can be fully tested by running `lily init` on a directory that already contains some or all of the expected artifacts, and verifying that existing files are preserved or updated appropriately without corruption.
+
+### Implementation for User Story 2
+
+- [X] T034 [US2] Implement file existence check in InitCommand.execute() (src/lily/core/application/commands/init.py): check if files exist before creating, skip existing files (idempotent behavior)
+- [X] T035 [US2] Implement missing file detection in InitCommand.execute() (src/lily/core/application/commands/init.py): identify which required artifacts are missing and create only those
+- [X] T036 [US2] Implement state.json corruption detection in InitCommand.validate() (src/lily/core/application/commands/init.py): validate JSON schema using StateModel, detect corruption
+- [X] T037 [US2] Implement state.json repair logic in InitCommand.execute() (src/lily/core/application/commands/init.py): recreate corrupted state.json with default values, log repair event
+- [X] T038 [US2] Implement log entry for skipped files in InitCommand.execute() (src/lily/core/application/commands/init.py): log "skipped" action for existing files in both log formats
+- [X] T039 [US2] Implement log entry for repaired files in InitCommand.execute() (src/lily/core/application/commands/init.py): log "repaired" action with metadata about corruption in both log formats
+- [X] T040 [US2] Update InitResult in InitCommand.execute() (src/lily/core/application/commands/init.py): include files_skipped list in result for re-initialization scenarios
+- [X] T041 [US2] Update console output in src/lily/ui/cli/main.py: display both created and skipped files when re-running init
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently. Running `lily init` multiple times should be idempotent and handle corruption repair.
+
+---
+
+## Phase 5: Error Handling & Edge Cases
+
+**Purpose**: Handle error scenarios and edge cases from specification
+
+- [X] T042 Implement permission validation in InitCommand.validate() (src/lily/core/application/commands/init.py): check write permissions before file operations, fail fast with clear error message
+- [X] T043 Implement permission error handling in InitCommand.execute() (src/lily/core/application/commands/init.py): catch permission errors, return InitError with failed_paths list
+- [X] T044 Implement invalid project name validation in InitCommand.validate() (src/lily/core/application/commands/init.py): validate project name for filesystem path compatibility
+- [X] T045 Implement error logging in InitCommand.execute() (src/lily/core/application/commands/init.py): log "failed" action to both log formats when errors occur
+- [X] T046 Update CLI error handling in src/lily/ui/cli/main.py: format and display error messages with specific failure reasons and paths
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [X] T047 [P] Add docstrings to all classes and methods in src/lily/core/application/commands/init.py
+- [X] T048 [P] Add docstrings to all classes and methods in src/lily/core/infrastructure/storage.py
+- [X] T049 [P] Add docstrings to all Pydantic models in src/lily/core/infrastructure/models/
+- [X] T050 Verify deterministic file creation: ensure all file content is deterministic (no random values, fixed timestamps for testing)
+- [X] T051 Verify idempotency: test that running init multiple times produces consistent results
+- [X] T051a [P] Add integration test in tests/integration/test_init_integration.py: verify SC-002 artifact count (6 user-facing markdown files + 5 system files + 1 docs README + 2 directory structures = 14 total artifacts)
+- [X] T052 Performance validation: ensure init completes in under 5 seconds (SC-001)
+- [X] T053 Verify log synchronization: ensure log.md and log.jsonl contain identical information
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational completion - MVP deliverable
+- **User Story 2 (Phase 4)**: Depends on User Story 1 completion (builds on idempotency)
+- **Error Handling (Phase 5)**: Can be done in parallel with User Story 2 or after
+- **Polish (Phase 6)**: Depends on all implementation phases being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories
+- **User Story 2 (P2)**: Depends on User Story 1 completion - Extends US1 with idempotency and repair features
+
+### Within Each User Story
+
+- Models before services (Pydantic models in Phase 2 before InitCommand in Phase 3)
+- Storage layer before command implementation
+- Command implementation before CLI integration
+- Core implementation before error handling
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel (T002)
+- All Foundational Pydantic model tasks marked [P] can run in parallel (T003-T007)
+- All generator tasks in User Story 1 marked [P] can run in parallel (T020-T026)
+- All documentation tasks in Polish phase marked [P] can run in parallel (T047-T049)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all markdown generators in parallel:
+Task: "Implement VisionGenerator in src/lily/core/infrastructure/storage.py"
+Task: "Implement GoalsGenerator in src/lily/core/infrastructure/storage.py"
+Task: "Implement NonGoalsGenerator in src/lily/core/infrastructure/storage.py"
+Task: "Implement ConstraintsGenerator in src/lily/core/infrastructure/storage.py"
+Task: "Implement AssumptionsGenerator in src/lily/core/infrastructure/storage.py"
+Task: "Implement OpenQuestionsGenerator in src/lily/core/infrastructure/storage.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test User Story 1 independently by running `lily init myproject` and verifying all files are created
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → Deploy/Demo (MVP!)
+3. Add User Story 2 → Test independently → Deploy/Demo (Idempotency + Repair)
+4. Add Error Handling → Test edge cases → Deploy/Demo
+5. Add Polish → Final validation → Deploy/Demo
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 (InitCommand, CLI)
+   - Developer B: User Story 2 (Idempotency, Repair) - can start after US1 core is done
+   - Developer C: Error Handling (can work in parallel)
+3. Stories complete and integrate independently
+
+---
+
+## Task Summary
+
+**Total Tasks**: 54
+
+**By Phase**:
+- Phase 1 (Setup): 2 tasks
+- Phase 2 (Foundational): 9 tasks
+- Phase 3 (User Story 1): 22 tasks
+- Phase 4 (User Story 2): 8 tasks
+- Phase 5 (Error Handling): 5 tasks
+- Phase 6 (Polish): 8 tasks
+
+**By User Story**:
+- User Story 1: 22 tasks
+- User Story 2: 8 tasks
+
+**Parallel Opportunities**: 16 tasks marked [P]
+
+**MVP Scope**: Phases 1-3 (User Story 1 only) = 33 tasks
+
+**Independent Test Criteria**:
+- **User Story 1**: Run `lily init myproject` in empty directory, verify all files created
+- **User Story 2**: Run `lily init` on existing project, verify idempotency and repair
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify deterministic behavior: same inputs produce same outputs
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence
+

--- a/docs/specs/002-docs-site-infrastructure/checklists/requirements.md
+++ b/docs/specs/002-docs-site-infrastructure/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Documentation Site Infrastructure
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Note: While the user mentioned "mkdocs and material" in the input, the specification focuses on outcomes (navigable site, search, dark mode, etc.) rather than implementation details
+

--- a/docs/specs/002-docs-site-infrastructure/contracts/justfile-targets.md
+++ b/docs/specs/002-docs-site-infrastructure/contracts/justfile-targets.md
@@ -1,0 +1,126 @@
+# Justfile Targets Contract
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15  
+**Type**: Command Interface Contract
+
+## Overview
+
+This contract defines the justfile targets that provide access to MkDocs functionality for documentation site development and building.
+
+## Target: `docs-serve`
+
+**Purpose**: Start local development server for documentation site with live reload
+
+**Command**: `just docs-serve`
+
+**Implementation**:
+```just
+docs-serve:
+    uv run mkdocs serve
+```
+
+**Behavior**:
+- Starts MkDocs development server (default: http://127.0.0.1:8000)
+- Watches docs/ directory for file changes
+- Automatically regenerates site when files change
+- Serves site at configured port (default 8000)
+- Runs until interrupted (Ctrl+C)
+
+**Prerequisites**:
+- MkDocs dependencies installed (`uv sync --group docs`)
+- `mkdocs.yml` configuration file exists
+- `docs/` directory exists with at least `index.md`
+
+**Success Criteria**:
+- Server starts without errors
+- Site is accessible at http://127.0.0.1:8000
+- File changes trigger automatic regeneration
+- Browser shows updated content after regeneration
+
+**Error Handling**:
+- If mkdocs.yml is invalid: Server fails to start with configuration error
+- If docs/ directory missing: Server fails with directory error
+- If dependencies missing: `uv run` fails with package not found error
+
+## Target: `docs-build`
+
+**Purpose**: Build static documentation site for deployment
+
+**Command**: `just docs-build`
+
+**Implementation**:
+```just
+docs-build:
+    uv run mkdocs build
+```
+
+**Behavior**:
+- Reads mkdocs.yml configuration
+- Processes all Markdown files in docs/ directory
+- Generates static HTML site in `site/` directory
+- Creates search index (search/search_index.json)
+- Outputs site ready for deployment
+
+**Prerequisites**:
+- MkDocs dependencies installed (`uv sync --group docs`)
+- `mkdocs.yml` configuration file exists
+- `docs/` directory exists with documentation files
+
+**Success Criteria**:
+- Build completes without errors
+- `site/` directory contains generated HTML files
+- All Markdown files are converted to HTML
+- Search index is generated
+- Site can be opened in browser (file:// or via web server)
+
+**Error Handling**:
+- If mkdocs.yml is invalid: Build fails with configuration error
+- If Markdown files have syntax errors: Build fails with file-specific error
+- If dependencies missing: `uv run` fails with package not found error
+- If site/ directory write fails: Build fails with permission error
+
+**Output**:
+- `site/` directory with generated static site
+- Directory structure mirrors docs/ structure
+- All assets (CSS, JS, images) included
+
+## Optional: `docs-clean`
+
+**Purpose**: Remove generated site directory
+
+**Command**: `just docs-clean` (optional, not required by spec)
+
+**Implementation** (if added):
+```just
+docs-clean:
+    rm -rf site/
+```
+
+**Behavior**:
+- Deletes `site/` directory and all contents
+- Useful for clean rebuilds
+
+## Contract Guarantees
+
+1. **Consistency**: Targets use `uv run` to ensure correct dependency versions
+2. **Error Visibility**: All errors are displayed to user with clear messages
+3. **Standard Workflow**: Targets follow standard MkDocs usage patterns
+4. **Integration**: Targets integrate seamlessly with existing justfile structure
+
+## Usage Examples
+
+**Local Development**:
+```bash
+just docs-serve
+# Open http://127.0.0.1:8000 in browser
+# Edit docs/*.md files
+# Changes appear automatically
+```
+
+**Build for Deployment**:
+```bash
+just docs-build
+# site/ directory contains deployable static site
+```
+

--- a/docs/specs/002-docs-site-infrastructure/contracts/mkdocs-config.md
+++ b/docs/specs/002-docs-site-infrastructure/contracts/mkdocs-config.md
@@ -1,0 +1,135 @@
+# MkDocs Configuration Contract
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15  
+**Type**: Configuration Contract
+
+## Overview
+
+This contract defines the expected structure and behavior of the `mkdocs.yml` configuration file that controls MkDocs site generation.
+
+## Configuration Schema
+
+### Required Fields
+
+- **site_name** (string): The title of the documentation site, displayed in the header and browser tab
+- **theme.name** (string): Must be "material" to use Material theme
+
+### Optional but Recommended Fields
+
+- **site_description** (string): Description of the site for metadata
+- **site_url** (string): Base URL for absolute links (required for GitHub Pages)
+- **repo_url** (string): Repository URL for "Edit on GitHub" links
+- **nav** (array): Navigation structure (auto-generated if omitted)
+
+### Theme Configuration
+
+**Material Theme Palette**:
+- Must define at least one color scheme (default light mode)
+- Should define dark mode scheme (slate) for dark mode toggle
+- Color values: Any valid CSS color (hex, rgb, named colors)
+
+**Material Theme Features**:
+- `search.suggest`: Enable search suggestions
+- `search.highlight`: Enable search result highlighting
+- `content.code.copy`: Enable copy button on code blocks
+- `navigation.tabs`: Enable tabbed navigation
+- `navigation.sections`: Enable section navigation
+- `navigation.top`: Enable back-to-top button
+
+### Plugin Configuration
+
+**Required Plugins**:
+- `search`: Built-in search functionality (no configuration needed)
+- `mermaid2`: Mermaid diagram rendering (default configuration sufficient)
+
+**Plugin Order**: Plugins are processed in order listed. `search` should typically be first.
+
+### Markdown Extensions
+
+**Recommended Extensions**:
+- `pymdownx.superfences`: Enhanced code fence support
+- `pymdownx.highlight`: Syntax highlighting
+- `admonition`: Admonition blocks (note, warning, etc.)
+- `pymdownx.details`: Collapsible details/summary blocks
+- `pymdownx.tabbed`: Tabbed content blocks
+- `attr_list`: Attribute lists for HTML attributes
+- `md_in_html`: Markdown within HTML blocks
+
+## Validation Rules
+
+1. **YAML Syntax**: Configuration must be valid YAML
+2. **Theme Name**: If theme is specified, name must be "material"
+3. **Plugin Names**: Plugin names must match installed plugin packages
+4. **Navigation**: If nav is specified, all referenced files must exist in docs/ directory
+5. **URLs**: site_url and repo_url should be valid URLs if provided
+
+## Error Handling
+
+**Invalid Configuration**:
+- MkDocs will fail with clear error messages indicating:
+  - Which field is invalid
+  - What the expected format is
+  - Which file/line caused the error
+
+**Missing Files**:
+- If nav references non-existent files, MkDocs will warn but may still build
+- Missing source files will cause build to fail with file path error
+
+## Example Configuration
+
+```yaml
+site_name: Lily Documentation
+site_description: Documentation for the Lily project orchestration framework
+site_url: https://username.github.io/lily/
+repo_url: https://github.com/username/lily
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+
+plugins:
+  - search
+  - mermaid2
+
+markdown_extensions:
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - admonition
+  - pymdownx.details
+  - pymdownx.tabbed
+  - attr_list
+  - md_in_html
+
+nav:
+  - Home: index.md
+  - Specs: specs/
+  - Ideas: ideas/
+```
+
+## Contract Guarantees
+
+1. **Deterministic Output**: Same configuration + same source files = same generated site
+2. **Error Messages**: Invalid configuration produces clear, actionable error messages
+3. **Backward Compatibility**: Configuration structure follows MkDocs conventions and will work with future MkDocs versions (within major version)
+4. **Feature Support**: Configuration enables all required features (search, dark mode, Mermaid diagrams)
+

--- a/docs/specs/002-docs-site-infrastructure/data-model.md
+++ b/docs/specs/002-docs-site-infrastructure/data-model.md
@@ -1,0 +1,166 @@
+# Data Model: Documentation Site Infrastructure
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15  
+**Phase**: 1 - Design
+
+## Overview
+
+This feature is an integration task with no application data model. However, there are configuration structures that define the system behavior.
+
+## Configuration Models
+
+### MkDocs Configuration (mkdocs.yml)
+
+**Purpose**: Defines site structure, appearance, and behavior
+
+**Structure**:
+```yaml
+site_name: string          # Site title displayed in header
+site_description: string   # Site description/metadata
+site_url: string          # Base URL for absolute links (GitHub Pages)
+repo_url: string          # Repository URL for "Edit on GitHub" links
+
+theme:
+  name: material          # Material theme identifier
+  palette:
+    - scheme: default     # Light mode scheme
+      primary: color       # Primary color
+      accent: color       # Accent color
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate       # Dark mode scheme
+      primary: color
+      accent: color
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - search.suggest      # Search suggestions
+    - search.highlight    # Search highlighting
+    - content.code.copy   # Copy code block button
+    - navigation.tabs     # Tabbed navigation
+    - navigation.sections # Section navigation
+    - navigation.top      # Back to top button
+
+plugins:
+  - search               # Built-in search plugin
+  - mermaid2             # Mermaid diagram plugin
+
+markdown_extensions:
+  - pymdownx.superfences # Enhanced code fences
+  - pymdownx.highlight   # Syntax highlighting
+  - admonition           # Admonition blocks
+  - pymdownx.details     # Details/summary blocks
+  - pymdownx.tabbed      # Tabbed content
+  - attr_list            # Attribute lists
+  - md_in_html           # Markdown in HTML
+
+nav:                      # Navigation structure (auto-generated from docs/ or manual)
+  - Home: index.md
+  - Specs: specs/
+  - Ideas: ideas/
+```
+
+**Validation Rules**:
+- `site_name` is required
+- `theme.name` must be "material" for Material theme
+- `plugins` must include "search" for search functionality
+- `plugins` must include "mermaid2" for Mermaid diagram support
+- `site_url` should be set for GitHub Pages deployment
+- `repo_url` should be set for "Edit on GitHub" links
+
+### Documentation Page Structure
+
+**Purpose**: Represents a single documentation page in the site
+
+**Attributes**:
+- **source_path**: Relative path from docs/ directory to Markdown source file
+- **generated_path**: Relative path from site/ directory to generated HTML file
+- **title**: Page title (extracted from first H1 or frontmatter)
+- **navigation_position**: Position in sidebar navigation (determined by file order or nav config)
+- **content**: Markdown content converted to HTML
+
+**Relationships**:
+- One source Markdown file → One generated HTML page
+- Pages organized hierarchically in navigation structure
+- Pages can reference other pages via relative links
+
+### Navigation Structure
+
+**Purpose**: Defines the hierarchical organization of pages in sidebar
+
+**Attributes**:
+- **items**: Array of navigation items (pages or sections)
+- **order**: Determined by file system order or explicit nav configuration
+- **nesting_levels**: Supports multiple levels of nesting
+
+**Structure**:
+- Top-level items appear in main sidebar
+- Nested items appear as expandable sections
+- Order can be explicit (nav config) or implicit (directory structure)
+
+## File System Structure
+
+### Source Files (docs/)
+
+```
+docs/
+├── index.md              # Homepage
+├── README.md             # Documentation overview (optional)
+├── specs/                # Specifications directory
+│   ├── 001-init-command/
+│   └── 002-docs-site-infrastructure/
+├── ideas/                # Ideas directory
+│   ├── commands/
+│   └── core/
+└── [other-docs].md       # Additional documentation files
+```
+
+### Generated Files (site/)
+
+```
+site/                     # Generated static site (gitignored)
+├── index.html
+├── specs/
+│   ├── 001-init-command/
+│   │   └── index.html
+│   └── 002-docs-site-infrastructure/
+│       └── index.html
+├── ideas/
+│   ├── commands/
+│   │   └── index.html
+│   └── core/
+│       └── index.html
+├── search/
+│   └── search_index.json # Search index
+└── assets/               # CSS, JS, images
+```
+
+## State Transitions
+
+### Site Generation Process
+
+1. **Source State**: Markdown files in docs/ directory
+2. **Configuration Load**: Read and validate mkdocs.yml
+3. **Processing**: MkDocs processes Markdown files
+4. **Generation**: HTML files generated in site/ directory
+5. **Index Creation**: Search index generated
+6. **Complete State**: Static site ready for viewing/deployment
+
+### Local Development Workflow
+
+1. **Start Server**: `just docs-serve` → MkDocs dev server starts
+2. **File Change**: User edits Markdown file
+3. **Auto-reload**: MkDocs detects change and regenerates
+4. **Browser Refresh**: Browser shows updated content
+
+## Notes
+
+- No database or persistent storage required
+- All state is file-based (source Markdown + generated HTML)
+- Configuration is YAML-based (mkdocs.yml)
+- Search index is generated JSON file
+- Site is fully static (no server-side processing)
+

--- a/docs/specs/002-docs-site-infrastructure/plan.md
+++ b/docs/specs/002-docs-site-infrastructure/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Documentation Site Infrastructure
+
+**Branch**: `002-docs-site-infrastructure` | **Date**: 2026-01-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-docs-site-infrastructure/spec.md`
+
+## Summary
+
+Integrate MkDocs with Material theme to transform Markdown documentation into a navigable, searchable documentation website. This is a configuration and integration task - no new code will be written. The implementation involves: (1) adding MkDocs dependencies to the project, (2) creating mkdocs.yml configuration file, (3) organizing documentation files into a docs/ directory structure, (4) adding justfile targets for local development server and site building, and (5) configuring GitHub Pages deployment support.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (existing project requirement)  
+**Primary Dependencies**: mkdocs, mkdocs-material, mkdocs-mermaid2-plugin (for Mermaid diagram support)  
+**Storage**: N/A (static site generation, filesystem-based)  
+**Testing**: N/A (integration task, no code to test)  
+**Target Platform**: Static HTML site (works in all modern browsers, deployable to GitHub Pages)  
+**Project Type**: Single Python project with CLI  
+**Performance Goals**: Site generation completes in under 30 seconds for typical documentation sets (up to 50 files), page loads in under 2 seconds  
+**Constraints**: Must work offline during generation, must produce static site (no server-side code), configuration must be file-based  
+**Scale/Scope**: Support documentation sets with up to 50 files initially, scalable to hundreds of files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Code Quality:**
+- [x] All code will meet production-quality standards (readable, maintainable, error handling)
+  - *N/A: This is an integration task with no new code*
+- [x] Code will be properly structured with clear separation of concerns
+  - *N/A: This is an integration task with no new code*
+- [x] Appropriate documentation will be included for complex behavior
+  - *Configuration files (mkdocs.yml) will include comments explaining structure*
+
+**Minimal Code Generation:**
+- [x] Implementation plan includes ONLY code required by specification
+  - *No code generation planned - only configuration and integration*
+- [x] No speculative features or "nice-to-have" items included
+  - *Plan includes only MkDocs setup, Material theme, Mermaid support, and justfile targets as specified*
+- [x] No premature abstractions or "future-proofing" code planned
+  - *N/A: No code planned*
+- [x] All planned code traces directly to specification requirements
+  - *All configuration and integration tasks map to functional requirements*
+
+**Gang of Four Patterns:**
+- [x] Design identifies which GoF patterns will be used (Command, Strategy, Template Method, State, Observer, Facade, Abstract Factory)
+  - *N/A: Integration task, no design patterns needed*
+
+**Testability:**
+- [x] Code structure enables unit and integration testing
+  - *N/A: No code to test. Manual verification: run `just docs-serve` and verify site loads*
+- [x] Critical paths have corresponding test plans
+  - *Manual verification plan: verify site generation, navigation, search, and deployment work*
+- [x] Test coverage targets are defined (minimum 80% for critical paths)
+  - *N/A: Integration task, manual verification sufficient*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-docs-site-infrastructure/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+# No source code changes - integration only
+# New files to be created:
+mkdocs.yml              # MkDocs configuration
+docs/                    # Documentation source directory
+  index.md              # Site homepage
+  README.md             # (may link to root README or be separate)
+  specs/                # Link/copy specs documentation
+  ideas/                # Link/copy ideas documentation
+  architecture.md       # Architecture documentation (if exists)
+site/                   # Generated site (gitignored, created by mkdocs build)
+  [generated HTML files]
+
+# Modified files:
+pyproject.toml          # Add mkdocs, mkdocs-material, mkdocs-mermaid2-plugin to dependencies
+justfile                # Add docs-serve and docs-build targets
+.gitignore              # Add site/ directory
+```
+
+**Structure Decision**: This is an integration task that adds configuration files and justfile targets. No source code structure changes needed. Documentation will be organized in a `docs/` directory at project root, following MkDocs conventions. The generated site will be output to `site/` directory (standard MkDocs output location).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations - this is a straightforward integration task with no code generation.
+
+## Phase Completion Status
+
+### Phase 0: Research ✅ Complete
+
+- [x] Research questions identified and resolved
+- [x] Technology choices documented (MkDocs, Material theme, Mermaid plugin)
+- [x] Configuration approach determined
+- [x] Justfile target patterns defined
+- [x] GitHub Pages deployment approach documented
+- [x] `research.md` generated with all decisions
+
+### Phase 1: Design & Contracts ✅ Complete
+
+- [x] Data model documented (configuration structures, file system layout)
+- [x] Contracts created:
+  - [x] `contracts/mkdocs-config.md` - MkDocs configuration contract
+  - [x] `contracts/justfile-targets.md` - Justfile targets contract
+- [x] `data-model.md` generated
+- [x] `quickstart.md` generated with setup and usage instructions
+- [x] Constitution check re-evaluated (all items pass)
+
+### Phase 2: Tasks
+
+**Status**: Pending `/speckit.tasks` command
+
+Phase 2 will break down the implementation into concrete tasks for:
+1. Adding dependencies to pyproject.toml
+2. Creating mkdocs.yml configuration
+3. Setting up docs/ directory structure
+4. Adding justfile targets
+5. Updating .gitignore
+6. Testing and verification
+
+## Next Steps
+
+The plan is complete through Phase 1. Ready for `/speckit.tasks` to create the task breakdown for implementation.

--- a/docs/specs/002-docs-site-infrastructure/quickstart.md
+++ b/docs/specs/002-docs-site-infrastructure/quickstart.md
@@ -1,0 +1,138 @@
+# Quickstart: Documentation Site Infrastructure
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15
+
+## Overview
+
+This quickstart guide explains how to set up and use the MkDocs documentation site infrastructure for the Lily project.
+
+## Prerequisites
+
+- Python 3.13+ installed
+- `uv` package manager installed
+- Project dependencies synced
+
+## Setup Steps
+
+### 1. Install Documentation Dependencies
+
+```bash
+uv sync --group docs
+```
+
+This installs:
+- `mkdocs` - Documentation site generator
+- `mkdocs-material` - Material theme for MkDocs
+- `mkdocs-mermaid2-plugin` - Mermaid diagram support
+
+### 2. Verify Configuration
+
+Ensure `mkdocs.yml` exists at project root with proper configuration (see contracts/mkdocs-config.md for details).
+
+### 3. Organize Documentation
+
+Ensure `docs/` directory exists with:
+- `index.md` - Site homepage
+- `specs/` - Specifications directory (can link to root specs/)
+- `ideas/` - Ideas directory (can link to root ideas/)
+- Any other documentation files
+
+### 4. Test Local Development Server
+
+```bash
+just docs-serve
+```
+
+Open http://127.0.0.1:8000 in your browser. You should see:
+- Site homepage
+- Sidebar navigation
+- Search functionality
+- Dark mode toggle
+
+### 5. Build Static Site
+
+```bash
+just docs-build
+```
+
+This generates the static site in `site/` directory, ready for deployment.
+
+## Common Workflows
+
+### Adding New Documentation
+
+1. Create or edit Markdown file in `docs/` directory
+2. If using `just docs-serve`, changes appear automatically
+3. If building manually, run `just docs-build` after changes
+
+### Adding Mermaid Diagrams
+
+In any Markdown file, use code blocks with `mermaid` language:
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B[Process]
+    B --> C[End]
+```
+````
+
+### Customizing Navigation
+
+Edit `mkdocs.yml` and add/update the `nav` section:
+
+```yaml
+nav:
+  - Home: index.md
+  - Specs: specs/
+  - Ideas: ideas/
+  - New Section: new-section.md
+```
+
+### Deploying to GitHub Pages
+
+**Option 1: Using mkdocs gh-deploy**
+```bash
+uv run mkdocs gh-deploy
+```
+
+**Option 2: Manual Deployment**
+1. Run `just docs-build`
+2. Copy contents of `site/` to `gh-pages` branch
+3. Push to GitHub
+
+## Troubleshooting
+
+### "mkdocs: command not found"
+
+**Solution**: Run `uv sync --group docs` to install dependencies
+
+### "Configuration file not found"
+
+**Solution**: Ensure `mkdocs.yml` exists at project root
+
+### "docs/ directory not found"
+
+**Solution**: Create `docs/` directory with at least `index.md`
+
+### Site not updating after file changes
+
+**Solution**: 
+- Check that `just docs-serve` is running
+- Verify file is saved
+- Check browser console for errors
+
+### Mermaid diagrams not rendering
+
+**Solution**:
+- Verify `mkdocs-mermaid2-plugin` is installed
+- Check that plugin is listed in `mkdocs.yml` plugins section
+- Ensure diagram syntax is correct
+
+## Next Steps
+
+- Review [mkdocs.yml configuration contract](./contracts/mkdocs-config.md)
+- Review [justfile targets contract](./contracts/justfile-targets.md)
+- See [data model](./data-model.md) for structure details
+- Check [research](./research.md) for design decisions

--- a/docs/specs/002-docs-site-infrastructure/research.md
+++ b/docs/specs/002-docs-site-infrastructure/research.md
@@ -1,0 +1,180 @@
+# Research: Documentation Site Infrastructure
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15  
+**Phase**: 0 - Research
+
+## Research Questions
+
+### 1. MkDocs Installation and Dependency Management
+
+**Question**: How should MkDocs and its plugins be added to a Python project using uv/pyproject.toml?
+
+**Decision**: Add MkDocs dependencies to `pyproject.toml` in a new dependency group called `docs` to keep documentation dependencies separate from runtime dependencies.
+
+**Rationale**: 
+- Keeps documentation tooling separate from application dependencies
+- Allows users to install docs dependencies only when needed: `uv sync --group docs`
+- Follows Python packaging best practices for optional dependencies
+- Compatible with uv dependency management
+
+**Alternatives considered**:
+- Adding to main dependencies: Rejected because docs tools aren't needed for application runtime
+- Separate requirements.txt: Rejected because project uses pyproject.toml for dependency management
+
+**Implementation**:
+```toml
+[dependency-groups]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocs-mermaid2-plugin>=1.1.0",
+]
+```
+
+### 2. MkDocs Configuration Structure
+
+**Question**: What is the optimal mkdocs.yml configuration structure for this project's documentation needs?
+
+**Decision**: Use a minimal mkdocs.yml with Material theme, search enabled, dark mode support, and Mermaid plugin configured. Navigation structure will mirror the docs/ directory organization.
+
+**Rationale**:
+- Minimal configuration aligns with project preference for "no ceremony"
+- Material theme provides all required features (search, dark mode, modern appearance)
+- Directory-based navigation is simpler than manual nav configuration
+- Mermaid plugin enables diagram rendering as specified
+
+**Alternatives considered**:
+- Manual navigation configuration: Rejected because directory-based is simpler and easier to maintain
+- Custom theme: Rejected because Material theme meets all requirements without customization overhead
+
+**Key Configuration Elements**:
+- Site name and description from project metadata
+- Material theme with dark mode toggle enabled
+- Search functionality enabled (default in Material)
+- Mermaid plugin for diagram support
+- Directory-based navigation (nav will auto-populate from docs/ structure)
+
+### 3. Documentation Directory Structure
+
+**Question**: How should existing documentation files be organized in the docs/ directory?
+
+**Decision**: Create a docs/ directory with:
+- `index.md` as the site homepage (can link to or incorporate README.md content)
+- `specs/` subdirectory (symlink or copy from root specs/)
+- `ideas/` subdirectory (symlink or copy from root ideas/)
+- Additional architecture/design docs as needed
+
+**Rationale**:
+- Follows MkDocs convention of docs/ as source directory
+- Preserves existing documentation organization
+- Allows incremental addition of new documentation
+- Symlinks or copies maintain connection to source files
+
+**Alternatives considered**:
+- Moving all docs to docs/: Rejected because it would disrupt existing project structure
+- Keeping docs at root: Rejected because MkDocs expects docs/ directory by default
+- Single flat structure: Rejected because hierarchical organization is clearer
+
+### 4. Justfile Targets for MkDocs
+
+**Question**: What justfile targets are needed for documentation site development?
+
+**Decision**: Create two justfile targets:
+- `docs-serve`: Start local development server (mkdocs serve)
+- `docs-build`: Build static site (mkdocs build)
+
+**Rationale**:
+- `docs-serve` enables local development with live reload
+- `docs-build` creates production-ready static site for deployment
+- Follows standard MkDocs workflow patterns
+- Integrates with existing justfile structure
+
+**Alternatives considered**:
+- Single target with flags: Rejected because separate targets are clearer and more intuitive
+- Additional deployment target: Deferred - GitHub Pages deployment can use mkdocs gh-deploy or be handled via CI/CD
+
+**Implementation**:
+```just
+# Serve documentation site locally
+docs-serve:
+    uv run mkdocs serve
+
+# Build documentation site
+docs-build:
+    uv run mkdocs build
+```
+
+### 5. Mermaid Diagram Support
+
+**Question**: How should Mermaid diagrams be configured in MkDocs?
+
+**Decision**: Use mkdocs-mermaid2-plugin with default configuration. Diagrams will be written in Markdown code blocks with `mermaid` language identifier.
+
+**Rationale**:
+- mkdocs-mermaid2-plugin is the recommended plugin for Material theme
+- Standard Markdown code block syntax is familiar and easy to use
+- Default configuration is sufficient for initial needs
+- Can be extended later if needed
+
+**Alternatives considered**:
+- mkdocs-mermaid-plugin (older): Rejected because mkdocs-mermaid2-plugin is actively maintained and recommended
+- Custom Mermaid integration: Rejected because plugin provides all needed functionality
+
+**Configuration**:
+```yaml
+plugins:
+  - search
+  - mermaid2
+```
+
+### 6. GitHub Pages Deployment Configuration
+
+**Question**: How should the site be configured for GitHub Pages deployment?
+
+**Decision**: Configure mkdocs.yml with site_url and repo_url for GitHub Pages. Use mkdocs gh-deploy command or GitHub Actions for deployment. Add site/ directory to .gitignore.
+
+**Rationale**:
+- site_url enables proper absolute URLs in generated site
+- repo_url enables "Edit on GitHub" links
+- site/ directory should be gitignored (generated content)
+- Deployment can be manual (gh-deploy) or automated (GitHub Actions)
+
+**Alternatives considered**:
+- Committing site/ directory: Rejected because generated content shouldn't be version controlled
+- Manual deployment only: Accepted as initial approach, can add GitHub Actions later if needed
+
+**Configuration**:
+```yaml
+site_url: https://[username].github.io/lily/
+repo_url: https://github.com/[username]/lily
+```
+
+### 7. Site Output Directory
+
+**Question**: Where should MkDocs output the generated site?
+
+**Decision**: Use default `site/` directory at project root. Add to .gitignore.
+
+**Rationale**:
+- Default MkDocs output location is standard and expected
+- Keeps generated files separate from source files
+- Easy to identify and clean up
+- Standard location for deployment tools
+
+**Alternatives considered**:
+- Custom output directory: Rejected because default is sufficient and standard
+- docs/_build/: Rejected because site/ is more standard for MkDocs
+
+## Summary of Decisions
+
+1. **Dependencies**: Add to `[dependency-groups]` in pyproject.toml as `docs` group
+2. **Configuration**: Minimal mkdocs.yml with Material theme, search, dark mode, Mermaid plugin
+3. **Documentation Structure**: docs/ directory with index.md, specs/, ideas/ subdirectories
+4. **Justfile Targets**: `docs-serve` and `docs-build` targets
+5. **Mermaid**: Use mkdocs-mermaid2-plugin with default configuration
+6. **GitHub Pages**: Configure site_url and repo_url, use gh-deploy or GitHub Actions
+7. **Output**: Use default `site/` directory, add to .gitignore
+
+All research questions resolved. Ready for Phase 1 design.
+

--- a/docs/specs/002-docs-site-infrastructure/spec.md
+++ b/docs/specs/002-docs-site-infrastructure/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Documentation Site Infrastructure
+
+**Feature Branch**: `002-docs-site-infrastructure`  
+**Created**: 2026-01-15  
+**Status**: Draft  
+**Input**: User description: "we are going to make the site infrastructure. we are using info in @ideas/docs_site.md using mkdocs and material"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Generate Documentation Site from Markdown (Priority: P1)
+
+A user wants to transform their project's Markdown documentation into a clean, navigable website that can be viewed locally or deployed to a hosting service. They have documentation files (architecture docs, specs, guides) in Markdown format and need a system that automatically converts these into a professional documentation site with navigation, search, and modern presentation.
+
+**Why this priority**: This is the core value proposition - converting existing Markdown documentation into a usable website. Without this capability, the feature provides no value.
+
+**Independent Test**: Can be fully tested by running the site generation command with existing Markdown files and verifying a complete, navigable website is produced that can be viewed in a browser.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project contains Markdown documentation files in organized directories, **When** the user runs the site generation command, **Then** a complete documentation website is generated with all Markdown files converted to web pages
+2. **Given** the generated documentation site, **When** a user opens it in a web browser, **Then** they can navigate between pages using a sidebar navigation menu that reflects the documentation structure
+3. **Given** the generated documentation site, **When** a user searches for content, **Then** they receive relevant search results from across all documentation pages
+4. **Given** the generated documentation site, **When** a user views it, **Then** the site displays with a modern, professional appearance including support for dark mode
+5. **Given** Markdown files contain Mermaid diagrams, **When** the site is generated, **Then** diagrams are rendered correctly as interactive visual elements in the web pages
+
+---
+
+### User Story 2 - Customize Site Appearance and Structure (Priority: P2)
+
+A user wants to configure the documentation site's appearance, navigation structure, and metadata to match their project's needs and branding preferences.
+
+**Why this priority**: While the default configuration should work well, users need the ability to customize site title, navigation order, theme settings, and other presentation aspects to align with their project identity.
+
+**Independent Test**: Can be fully tested by modifying configuration files and regenerating the site, then verifying that changes are reflected in the generated website.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user wants to customize the site title and description, **When** they modify the configuration file, **Then** the generated site displays the custom title and metadata
+2. **Given** a user wants to reorder navigation items, **When** they update the configuration, **Then** the sidebar navigation reflects the new order in the generated site
+3. **Given** a user wants to enable or disable specific features (search, dark mode, etc.), **When** they configure these options, **Then** the generated site includes or excludes these features accordingly
+4. **Given** a user wants to add custom styling or branding, **When** they provide custom assets or configuration, **Then** the generated site incorporates these customizations
+
+---
+
+### User Story 3 - Deploy Documentation Site (Priority: P2)
+
+A user wants to publish their documentation site to a hosting service (such as GitHub Pages) so that team members and stakeholders can access it via a URL.
+
+**Why this priority**: While local viewing is valuable, the ability to share documentation via a hosted URL is essential for collaboration and stakeholder access.
+
+**Independent Test**: Can be fully tested by running the deployment command and verifying the site is accessible at the expected URL with all content properly rendered.
+
+**Acceptance Scenarios**:
+
+1. **Given** a documentation site has been generated, **When** the user runs the deployment command, **Then** the site is published to the configured hosting service and accessible via URL
+2. **Given** a user wants to deploy to GitHub Pages, **When** they configure the deployment settings, **Then** the site is automatically built and published to the appropriate GitHub Pages location
+3. **Given** documentation is updated, **When** the user regenerates and redeploys, **Then** the hosted site reflects the latest changes
+
+---
+
+### Edge Cases
+
+- What happens when Markdown files contain syntax errors? → System should either gracefully handle errors (skip problematic files with warnings) or fail with clear error messages indicating which files have issues
+- How does the system handle very large documentation sets (hundreds of files)? → Site generation should complete successfully and the generated site should remain performant with reasonable page load times
+- What happens when configuration files are missing or invalid? → System should provide sensible defaults or fail with clear error messages explaining what configuration is needed
+- How does the system handle special characters or non-ASCII content in Markdown? → All content should be properly encoded and displayed correctly in the generated site
+- What happens when the output directory already contains files from a previous generation? → System should either overwrite cleanly or merge appropriately without leaving orphaned files
+- How does the system behave when documentation files are moved or renamed? → Navigation should update correctly to reflect the new structure, and old links should either redirect or be clearly marked as broken
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST convert Markdown documentation files into a complete, navigable website with HTML pages
+- **FR-002**: System MUST generate a sidebar navigation menu that reflects the hierarchical structure of the documentation
+- **FR-003**: System MUST provide full-text search functionality across all documentation pages in the generated site
+- **FR-004**: System MUST support dark mode display option that users can toggle
+- **FR-005**: System MUST render Mermaid diagrams from Markdown source into interactive visual elements in the web pages
+- **FR-006**: System MUST allow users to configure site metadata (title, description, author, etc.) through configuration files
+- **FR-007**: System MUST allow users to customize navigation structure and ordering through configuration
+- **FR-008**: System MUST support local viewing of the generated site (users can open and navigate the site in their web browser without a server)
+- **FR-009**: System MUST support deployment to hosting services (with GitHub Pages as a primary target)
+- **FR-010**: System MUST preserve Markdown formatting (headers, lists, code blocks, links, etc.) in the generated web pages
+- **FR-011**: System MUST handle documentation organized in multiple directories and subdirectories, maintaining the structure in navigation
+- **FR-012**: System MUST provide clear error messages when generation fails, indicating which files or configuration caused the issue
+- **FR-013**: System MUST generate a site that loads pages quickly (within reasonable performance expectations for static sites)
+- **FR-014**: System MUST support incremental updates (regenerating only changed content when possible, though full regeneration is acceptable)
+- **FR-015**: System MUST ensure the generated site works across modern web browsers (Chrome, Firefox, Safari, Edge)
+
+### Key Entities *(include if feature involves data)*
+
+- **Documentation Page**: Represents a single page in the generated documentation site, derived from a Markdown source file. Key attributes include source file path, generated HTML path, page title, navigation position, and content.
+- **Navigation Structure**: Represents the hierarchical organization of documentation pages in the sidebar menu. Key attributes include page order, nesting levels, section groupings, and display labels.
+- **Site Configuration**: Represents user-defined settings that control site generation, appearance, and behavior. Key attributes include site title, description, navigation structure, theme preferences, and deployment settings.
+- **Generated Site**: Represents the complete output of the site generation process. Key attributes include output directory location, total pages generated, search index, and deployment status.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can generate a complete documentation site from Markdown files in under 30 seconds for typical documentation sets (up to 50 files)
+- **SC-002**: 100% of valid Markdown files are successfully converted to web pages with all formatting preserved (headers, lists, code blocks, links render correctly)
+- **SC-003**: Generated sites provide search functionality that returns relevant results for user queries within 1 second
+- **SC-004**: Users can navigate between any two pages in the documentation site using sidebar navigation in 2 clicks or fewer
+- **SC-005**: Generated sites load initial page in under 2 seconds on standard broadband connections
+- **SC-006**: Users can successfully deploy documentation sites to GitHub Pages with a single command execution
+- **SC-007**: Generated sites are accessible and functional across all target browsers (Chrome, Firefox, Safari, Edge) with 100% feature parity
+- **SC-008**: Mermaid diagrams render correctly in 100% of cases where valid Mermaid syntax is provided in source Markdown
+
+## Assumptions
+
+- Users have Markdown documentation files already created in their project
+- Users have write permissions to create output directories for generated sites
+- Users have internet access when deploying to hosting services (for GitHub Pages deployment)
+- Documentation files follow standard Markdown syntax conventions
+- Users are familiar with basic Markdown formatting
+- The project structure includes organized directories for documentation files
+- Users want a static site (no server-side processing required for viewing)
+
+## Dependencies
+
+- Markdown parsing and conversion capabilities
+- File system operations for reading source files and writing generated output
+- Configuration file parsing and validation
+- Deployment integration with hosting services (GitHub Pages API or similar)
+
+## Constraints
+
+- Site generation must work offline (no external API calls required during generation, except for deployment)
+- Generated sites must be static (no server-side code execution required for viewing)
+- Configuration must be file-based (not interactive prompts during generation)
+- Site generation should be deterministic (same inputs produce same outputs)
+- The system must not modify source Markdown files (read-only access to sources)
+

--- a/docs/specs/002-docs-site-infrastructure/tasks.md
+++ b/docs/specs/002-docs-site-infrastructure/tasks.md
@@ -1,0 +1,209 @@
+# Implementation Tasks: Documentation Site Infrastructure
+
+**Feature**: Documentation Site Infrastructure  
+**Branch**: `002-docs-site-infrastructure`  
+**Date**: 2026-01-15  
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+## Summary
+
+This document breaks down the implementation of MkDocs documentation site infrastructure into actionable tasks. This is an **integration task** with **no code generation** - all work involves configuration files, directory setup, and justfile targets.
+
+**Total Tasks**: 23  
+**Setup (Phase 1)**: 3 tasks  
+**Foundational (Phase 2)**: 4 tasks  
+**User Story 1 (P1)**: 8 tasks  
+**User Story 2 (P2)**: 3 tasks  
+**User Story 3 (P2)**: 2 tasks  
+**Polish**: 3 tasks
+
+## Implementation Strategy
+
+**MVP Scope**: Complete User Story 1 (Generate Documentation Site from Markdown) - this delivers the core value proposition and enables all other stories.
+
+**Incremental Delivery**:
+1. **Phase 1-2**: Setup and foundational configuration (enables all stories)
+2. **Phase 3**: User Story 1 - Core site generation (MVP)
+3. **Phase 4**: User Story 2 - Customization (enhancement)
+4. **Phase 5**: User Story 3 - Deployment (enhancement)
+5. **Final**: Polish and verification
+
+## Dependencies
+
+**Story Completion Order**:
+- **User Story 1** (P1) must complete first - it provides the core functionality
+- **User Story 2** (P2) can start after User Story 1 - it enhances configuration
+- **User Story 3** (P2) requires User Story 1 - it deploys the generated site
+- **Polish** requires all user stories - it adds convenience features
+
+**Parallel Opportunities**:
+- Tasks T001-T003 can be done in parallel (different files)
+- Tasks T004-T005 can be done in parallel (different files)
+- Tasks T006-T007 can be done in parallel (different files)
+- Tasks T011-T012 can be done in parallel (different files)
+
+---
+
+## Phase 1: Setup
+
+**Goal**: Prepare project for MkDocs integration by adding dependencies and creating directory structure.
+
+**Independent Test**: After Phase 1, running `uv sync --group docs` should install MkDocs dependencies, and `docs/` directory should exist with basic structure.
+
+### Tasks
+
+- [ ] T001 Add MkDocs dependencies to pyproject.toml dependency groups in pyproject.toml
+- [ ] T002 [P] Create docs/ directory structure in docs/
+- [ ] T003 [P] Create docs/index.md homepage file in docs/index.md
+
+---
+
+## Phase 2: Foundational Configuration
+
+**Goal**: Create basic MkDocs configuration file that enables site generation with Material theme, search, and Mermaid support.
+
+**Independent Test**: After Phase 2, `mkdocs.yml` exists with valid configuration. Running `uv run mkdocs build` should succeed (even if docs/ is mostly empty).
+
+### Tasks
+
+- [ ] T004 Create mkdocs.yml configuration file with site metadata in mkdocs.yml
+- [ ] T005 [P] Configure Material theme with dark mode support in mkdocs.yml
+- [ ] T006 [P] Configure search plugin in mkdocs.yml
+- [ ] T007 [P] Configure mermaid2 plugin in mkdocs.yml
+
+---
+
+## Phase 3: User Story 1 - Generate Documentation Site from Markdown (P1)
+
+**Goal**: Enable users to transform Markdown documentation into a navigable website with search, dark mode, and Mermaid diagram support.
+
+**Independent Test**: After Phase 3, users can:
+1. Run `just docs-build` to generate a complete static site
+2. Run `just docs-serve` to view site locally with live reload
+3. Navigate between pages using sidebar navigation
+4. Search for content across all pages
+5. Toggle dark mode
+6. View Mermaid diagrams rendered correctly
+
+**Acceptance Criteria** (from spec):
+- ✅ All Markdown files converted to HTML pages
+- ✅ Sidebar navigation reflects documentation structure
+- ✅ Full-text search works across all pages
+- ✅ Dark mode toggle functions
+- ✅ Mermaid diagrams render correctly
+
+### Tasks
+
+- [ ] T008 [US1] Organize existing documentation into docs/ directory structure in docs/
+- [ ] T009 [US1] Create navigation structure linking specs/ and ideas/ in mkdocs.yml
+- [ ] T010 [US1] Add docs-serve justfile target for local development server in justfile
+- [ ] T011 [US1] [P] Add docs-build justfile target for static site generation in justfile
+- [ ] T012 [US1] [P] Verify site generation produces complete navigable website (manual verification)
+- [ ] T013 [US1] Verify search functionality works across all pages (manual verification)
+- [ ] T014 [US1] Verify dark mode toggle functions correctly (manual verification)
+- [ ] T015 [US1] Verify Mermaid diagrams render correctly (manual verification - add test diagram if needed)
+
+---
+
+## Phase 4: User Story 2 - Customize Site Appearance and Structure (P2)
+
+**Goal**: Enable users to customize site title, description, navigation order, and theme settings through configuration.
+
+**Independent Test**: After Phase 4, users can modify `mkdocs.yml` to change site title, description, navigation order, and theme colors, and see changes reflected in generated site.
+
+**Acceptance Criteria** (from spec):
+- ✅ Site title and description customizable
+- ✅ Navigation order configurable
+- ✅ Theme features (search, dark mode) can be enabled/disabled
+- ✅ Custom styling/branding can be added
+
+### Tasks
+
+- [ ] T016 [US2] Add site_name and site_description configuration with project-specific values in mkdocs.yml
+- [ ] T017 [US2] Document navigation customization options in mkdocs.yml (add comments)
+- [ ] T018 [US2] Verify customization changes are reflected in generated site (manual verification)
+
+---
+
+## Phase 5: User Story 3 - Deploy Documentation Site (P2)
+
+**Goal**: Enable users to deploy documentation site to GitHub Pages.
+
+**Independent Test**: After Phase 5, users can configure GitHub Pages deployment settings and deploy site using `mkdocs gh-deploy` or similar method.
+
+**Acceptance Criteria** (from spec):
+- ✅ Site can be deployed to GitHub Pages
+- ✅ Deployment configuration is documented
+- ✅ Deployed site is accessible via URL
+
+### Tasks
+
+- [ ] T019 [US3] Add site_url and repo_url configuration for GitHub Pages in mkdocs.yml
+- [ ] T020 [US3] Document GitHub Pages deployment process in quickstart.md or README
+
+---
+
+## Final Phase: Polish & Cross-Cutting Concerns
+
+**Goal**: Add convenience features, verify .gitignore, and ensure all requirements are met.
+
+**Independent Test**: After Final Phase, all justfile targets work, generated site is gitignored, and complete feature verification passes.
+
+### Tasks
+
+- [ ] T021 Verify site/ directory is in .gitignore (check existing entry)
+- [ ] T022 Add optional docs-clean justfile target for removing generated site (optional enhancement)
+- [ ] T023 Complete feature verification: test all acceptance scenarios from spec (manual verification)
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1 Tasks (T008-T015)
+
+**Parallel Group 1** (can run simultaneously):
+- T011: Add docs-build target (justfile)
+- T012: Verify site generation (manual)
+
+**Parallel Group 2** (can run simultaneously):
+- T013: Verify search (manual)
+- T014: Verify dark mode (manual)
+- T015: Verify Mermaid (manual)
+
+### Setup Tasks (T001-T003)
+
+**Parallel Group** (can run simultaneously):
+- T002: Create docs/ directory
+- T003: Create docs/index.md
+
+### Configuration Tasks (T004-T007)
+
+**Parallel Group** (can run simultaneously):
+- T005: Configure Material theme
+- T006: Configure search plugin
+- T007: Configure mermaid2 plugin
+
+---
+
+## Task Completion Checklist
+
+Before marking feature complete, verify:
+
+- [ ] All Phase 1-2 tasks complete (setup and foundational config)
+- [ ] User Story 1 fully implemented and tested (core functionality)
+- [ ] User Story 2 fully implemented and tested (customization)
+- [ ] User Story 3 fully implemented and tested (deployment)
+- [ ] All justfile targets work correctly
+- [ ] Generated site is gitignored
+- [ ] All acceptance scenarios from spec pass
+- [ ] Quickstart guide is accurate
+
+---
+
+## Notes
+
+- **No code generation**: All tasks involve configuration, file creation, and integration only
+- **Manual verification**: Testing is done by running commands and verifying output in browser
+- **Incremental delivery**: Each phase builds on previous phases
+- **MVP**: Phase 3 (User Story 1) delivers core value and can be used independently
+

--- a/ideas/docs_site.md
+++ b/ideas/docs_site.md
@@ -1,0 +1,112 @@
+For our Python projects, when we want **Markdown-based documentation that turns into a clean, navigable site**, we almost always reach for one of these—ranked by how well they fit *our* style and workflows:
+
+---
+
+### **1. MkDocs (default choice)**
+
+**This is the one we usually mean.**
+
+**Why it fits us so well**
+
+* Native **Markdown-first**
+* Minimal configuration, fast to stand up
+* Excellent for **architecture docs, ADRs, workflows, and specs**
+* Plays nicely with GitHub Pages
+* Clean sidebar navigation from `mkdocs.yml`
+
+**Typical stack**
+
+```text
+docs/
+  index.md
+  architecture.md
+  design.md
+  roadmap.md
+  api.md
+mkdocs.yml
+```
+
+**Common theme**
+
+* `mkdocs-material` (this is what gives it the polished look)
+
+**Why I favor it**
+
+* No ceremony
+* Docs feel like “living design notes,” not academic papers
+* Perfect for systems like Chrona / Petal / Lily where architecture evolves
+
+---
+
+### **2. MkDocs + Material Theme**
+
+This is technically MkDocs, but it deserves its own callout.
+
+**Adds**
+
+* Versioned docs
+* Search (excellent)
+* Tabs, callouts, diagrams, admonitions
+* Dark mode (important, obviously 😌)
+
+**Bonus**
+
+* Mermaid diagrams work cleanly
+* Great for CLI + TUI documentation
+
+If we say *“real docs site”*, this is usually what we mean.
+
+---
+
+### **3. Sphinx (only when API docs dominate)**
+
+Still Markdown-capable via **MyST**, but…
+
+**We use it when**
+
+* Auto-generated API reference is the primary goal
+* Heavy docstring extraction
+* ReadTheDocs style expectations
+
+**Why it’s not our default**
+
+* Heavier mental overhead
+* More config
+* Feels slower for early-stage system design
+
+I treat Sphinx as **API-first**, not **architecture-first**.
+
+---
+
+### **4. Docusaurus (rare for Python)**
+
+Markdown-based, yes—but…
+
+**Why we usually skip it**
+
+* JS ecosystem overhead
+* Better for product docs than dev architecture
+* Less natural fit for Python repos
+
+---
+
+### **My recommendation (and what we “usually” mean)**
+
+If you asked this instinctively, the answer is:
+
+> **MkDocs + Material + Markdown**
+
+It aligns perfectly with:
+
+* Spec-Kit style thinking
+* Incremental architecture evolution
+* CLI/TUI tool documentation
+* GitHub-native workflows
+
+If you want, I can:
+
+* Scaffold a **drop-in MkDocs setup**
+* Propose a **docs IA** (information architecture)
+* Or align it with the CLI/TUI split we were discussing earlier
+
+Just say the word—I’ll make it neat and opinionated 💜

--- a/justfile
+++ b/justfile
@@ -14,3 +14,15 @@ quality:
     uv run ruff check --fix .
     uv run mypy src/lily
 
+# Serve documentation site locally
+docs-serve:
+    uv run mkdocs serve
+
+# Build documentation site
+docs-build:
+    uv run mkdocs build
+
+# Clean generated documentation site
+docs-clean:
+    rm -rf site/
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+# MkDocs Configuration for Lily Documentation Site
+# See contracts/mkdocs-config.md for configuration contract details
+
+site_name: Lily Documentation
+site_description: Documentation for the Lily project orchestration framework
+# GitHub Pages configuration - update these URLs with your actual repository
+site_url: https://username.github.io/lily/  # Update with your GitHub Pages URL
+repo_url: https://github.com/username/lily  # Update with your repository URL
+
+# Material theme configuration
+theme:
+  name: material
+  palette:
+    # Light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - search.suggest      # Search suggestions
+    - search.highlight    # Search result highlighting
+    - content.code.copy   # Copy button on code blocks
+    - navigation.tabs     # Tabbed navigation
+    - navigation.sections # Section navigation
+    - navigation.top     # Back to top button
+
+# Plugins configuration
+plugins:
+  - search               # Built-in search functionality
+  - mermaid2             # Mermaid diagram support
+
+# Markdown extensions
+markdown_extensions:
+  - pymdownx.superfences # Enhanced code fence support
+  - pymdownx.highlight   # Syntax highlighting
+  - admonition           # Admonition blocks (note, warning, etc.)
+  - pymdownx.details     # Collapsible details/summary blocks
+  - pymdownx.tabbed      # Tabbed content blocks
+  - attr_list            # Attribute lists for HTML attributes
+  - md_in_html           # Markdown within HTML blocks
+
+# Navigation structure
+# Navigation will auto-populate from docs/ directory structure
+# You can customize the order here if needed
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Architecture: architecture.md
+  - Commands: commands/
+  - Specifications: specs/
+  - Ideas: ideas/
+  - Deployment: deployment.md
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dev = [
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",
 ]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocs-mermaid2-plugin>=1.1.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/specs/002-docs-site-infrastructure/checklists/requirements.md
+++ b/specs/002-docs-site-infrastructure/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Documentation Site Infrastructure
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Note: While the user mentioned "mkdocs and material" in the input, the specification focuses on outcomes (navigable site, search, dark mode, etc.) rather than implementation details
+

--- a/specs/002-docs-site-infrastructure/contracts/justfile-targets.md
+++ b/specs/002-docs-site-infrastructure/contracts/justfile-targets.md
@@ -1,0 +1,126 @@
+# Justfile Targets Contract
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15  
+**Type**: Command Interface Contract
+
+## Overview
+
+This contract defines the justfile targets that provide access to MkDocs functionality for documentation site development and building.
+
+## Target: `docs-serve`
+
+**Purpose**: Start local development server for documentation site with live reload
+
+**Command**: `just docs-serve`
+
+**Implementation**:
+```just
+docs-serve:
+    uv run mkdocs serve
+```
+
+**Behavior**:
+- Starts MkDocs development server (default: http://127.0.0.1:8000)
+- Watches docs/ directory for file changes
+- Automatically regenerates site when files change
+- Serves site at configured port (default 8000)
+- Runs until interrupted (Ctrl+C)
+
+**Prerequisites**:
+- MkDocs dependencies installed (`uv sync --group docs`)
+- `mkdocs.yml` configuration file exists
+- `docs/` directory exists with at least `index.md`
+
+**Success Criteria**:
+- Server starts without errors
+- Site is accessible at http://127.0.0.1:8000
+- File changes trigger automatic regeneration
+- Browser shows updated content after regeneration
+
+**Error Handling**:
+- If mkdocs.yml is invalid: Server fails to start with configuration error
+- If docs/ directory missing: Server fails with directory error
+- If dependencies missing: `uv run` fails with package not found error
+
+## Target: `docs-build`
+
+**Purpose**: Build static documentation site for deployment
+
+**Command**: `just docs-build`
+
+**Implementation**:
+```just
+docs-build:
+    uv run mkdocs build
+```
+
+**Behavior**:
+- Reads mkdocs.yml configuration
+- Processes all Markdown files in docs/ directory
+- Generates static HTML site in `site/` directory
+- Creates search index (search/search_index.json)
+- Outputs site ready for deployment
+
+**Prerequisites**:
+- MkDocs dependencies installed (`uv sync --group docs`)
+- `mkdocs.yml` configuration file exists
+- `docs/` directory exists with documentation files
+
+**Success Criteria**:
+- Build completes without errors
+- `site/` directory contains generated HTML files
+- All Markdown files are converted to HTML
+- Search index is generated
+- Site can be opened in browser (file:// or via web server)
+
+**Error Handling**:
+- If mkdocs.yml is invalid: Build fails with configuration error
+- If Markdown files have syntax errors: Build fails with file-specific error
+- If dependencies missing: `uv run` fails with package not found error
+- If site/ directory write fails: Build fails with permission error
+
+**Output**:
+- `site/` directory with generated static site
+- Directory structure mirrors docs/ structure
+- All assets (CSS, JS, images) included
+
+## Optional: `docs-clean`
+
+**Purpose**: Remove generated site directory
+
+**Command**: `just docs-clean` (optional, not required by spec)
+
+**Implementation** (if added):
+```just
+docs-clean:
+    rm -rf site/
+```
+
+**Behavior**:
+- Deletes `site/` directory and all contents
+- Useful for clean rebuilds
+
+## Contract Guarantees
+
+1. **Consistency**: Targets use `uv run` to ensure correct dependency versions
+2. **Error Visibility**: All errors are displayed to user with clear messages
+3. **Standard Workflow**: Targets follow standard MkDocs usage patterns
+4. **Integration**: Targets integrate seamlessly with existing justfile structure
+
+## Usage Examples
+
+**Local Development**:
+```bash
+just docs-serve
+# Open http://127.0.0.1:8000 in browser
+# Edit docs/*.md files
+# Changes appear automatically
+```
+
+**Build for Deployment**:
+```bash
+just docs-build
+# site/ directory contains deployable static site
+```
+

--- a/specs/002-docs-site-infrastructure/contracts/mkdocs-config.md
+++ b/specs/002-docs-site-infrastructure/contracts/mkdocs-config.md
@@ -1,0 +1,135 @@
+# MkDocs Configuration Contract
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15  
+**Type**: Configuration Contract
+
+## Overview
+
+This contract defines the expected structure and behavior of the `mkdocs.yml` configuration file that controls MkDocs site generation.
+
+## Configuration Schema
+
+### Required Fields
+
+- **site_name** (string): The title of the documentation site, displayed in the header and browser tab
+- **theme.name** (string): Must be "material" to use Material theme
+
+### Optional but Recommended Fields
+
+- **site_description** (string): Description of the site for metadata
+- **site_url** (string): Base URL for absolute links (required for GitHub Pages)
+- **repo_url** (string): Repository URL for "Edit on GitHub" links
+- **nav** (array): Navigation structure (auto-generated if omitted)
+
+### Theme Configuration
+
+**Material Theme Palette**:
+- Must define at least one color scheme (default light mode)
+- Should define dark mode scheme (slate) for dark mode toggle
+- Color values: Any valid CSS color (hex, rgb, named colors)
+
+**Material Theme Features**:
+- `search.suggest`: Enable search suggestions
+- `search.highlight`: Enable search result highlighting
+- `content.code.copy`: Enable copy button on code blocks
+- `navigation.tabs`: Enable tabbed navigation
+- `navigation.sections`: Enable section navigation
+- `navigation.top`: Enable back-to-top button
+
+### Plugin Configuration
+
+**Required Plugins**:
+- `search`: Built-in search functionality (no configuration needed)
+- `mermaid2`: Mermaid diagram rendering (default configuration sufficient)
+
+**Plugin Order**: Plugins are processed in order listed. `search` should typically be first.
+
+### Markdown Extensions
+
+**Recommended Extensions**:
+- `pymdownx.superfences`: Enhanced code fence support
+- `pymdownx.highlight`: Syntax highlighting
+- `admonition`: Admonition blocks (note, warning, etc.)
+- `pymdownx.details`: Collapsible details/summary blocks
+- `pymdownx.tabbed`: Tabbed content blocks
+- `attr_list`: Attribute lists for HTML attributes
+- `md_in_html`: Markdown within HTML blocks
+
+## Validation Rules
+
+1. **YAML Syntax**: Configuration must be valid YAML
+2. **Theme Name**: If theme is specified, name must be "material"
+3. **Plugin Names**: Plugin names must match installed plugin packages
+4. **Navigation**: If nav is specified, all referenced files must exist in docs/ directory
+5. **URLs**: site_url and repo_url should be valid URLs if provided
+
+## Error Handling
+
+**Invalid Configuration**:
+- MkDocs will fail with clear error messages indicating:
+  - Which field is invalid
+  - What the expected format is
+  - Which file/line caused the error
+
+**Missing Files**:
+- If nav references non-existent files, MkDocs will warn but may still build
+- Missing source files will cause build to fail with file path error
+
+## Example Configuration
+
+```yaml
+site_name: Lily Documentation
+site_description: Documentation for the Lily project orchestration framework
+site_url: https://username.github.io/lily/
+repo_url: https://github.com/username/lily
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+
+plugins:
+  - search
+  - mermaid2
+
+markdown_extensions:
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - admonition
+  - pymdownx.details
+  - pymdownx.tabbed
+  - attr_list
+  - md_in_html
+
+nav:
+  - Home: index.md
+  - Specs: specs/
+  - Ideas: ideas/
+```
+
+## Contract Guarantees
+
+1. **Deterministic Output**: Same configuration + same source files = same generated site
+2. **Error Messages**: Invalid configuration produces clear, actionable error messages
+3. **Backward Compatibility**: Configuration structure follows MkDocs conventions and will work with future MkDocs versions (within major version)
+4. **Feature Support**: Configuration enables all required features (search, dark mode, Mermaid diagrams)
+

--- a/specs/002-docs-site-infrastructure/data-model.md
+++ b/specs/002-docs-site-infrastructure/data-model.md
@@ -1,0 +1,166 @@
+# Data Model: Documentation Site Infrastructure
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15  
+**Phase**: 1 - Design
+
+## Overview
+
+This feature is an integration task with no application data model. However, there are configuration structures that define the system behavior.
+
+## Configuration Models
+
+### MkDocs Configuration (mkdocs.yml)
+
+**Purpose**: Defines site structure, appearance, and behavior
+
+**Structure**:
+```yaml
+site_name: string          # Site title displayed in header
+site_description: string   # Site description/metadata
+site_url: string          # Base URL for absolute links (GitHub Pages)
+repo_url: string          # Repository URL for "Edit on GitHub" links
+
+theme:
+  name: material          # Material theme identifier
+  palette:
+    - scheme: default     # Light mode scheme
+      primary: color       # Primary color
+      accent: color       # Accent color
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate       # Dark mode scheme
+      primary: color
+      accent: color
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - search.suggest      # Search suggestions
+    - search.highlight    # Search highlighting
+    - content.code.copy   # Copy code block button
+    - navigation.tabs     # Tabbed navigation
+    - navigation.sections # Section navigation
+    - navigation.top      # Back to top button
+
+plugins:
+  - search               # Built-in search plugin
+  - mermaid2             # Mermaid diagram plugin
+
+markdown_extensions:
+  - pymdownx.superfences # Enhanced code fences
+  - pymdownx.highlight   # Syntax highlighting
+  - admonition           # Admonition blocks
+  - pymdownx.details     # Details/summary blocks
+  - pymdownx.tabbed      # Tabbed content
+  - attr_list            # Attribute lists
+  - md_in_html           # Markdown in HTML
+
+nav:                      # Navigation structure (auto-generated from docs/ or manual)
+  - Home: index.md
+  - Specs: specs/
+  - Ideas: ideas/
+```
+
+**Validation Rules**:
+- `site_name` is required
+- `theme.name` must be "material" for Material theme
+- `plugins` must include "search" for search functionality
+- `plugins` must include "mermaid2" for Mermaid diagram support
+- `site_url` should be set for GitHub Pages deployment
+- `repo_url` should be set for "Edit on GitHub" links
+
+### Documentation Page Structure
+
+**Purpose**: Represents a single documentation page in the site
+
+**Attributes**:
+- **source_path**: Relative path from docs/ directory to Markdown source file
+- **generated_path**: Relative path from site/ directory to generated HTML file
+- **title**: Page title (extracted from first H1 or frontmatter)
+- **navigation_position**: Position in sidebar navigation (determined by file order or nav config)
+- **content**: Markdown content converted to HTML
+
+**Relationships**:
+- One source Markdown file → One generated HTML page
+- Pages organized hierarchically in navigation structure
+- Pages can reference other pages via relative links
+
+### Navigation Structure
+
+**Purpose**: Defines the hierarchical organization of pages in sidebar
+
+**Attributes**:
+- **items**: Array of navigation items (pages or sections)
+- **order**: Determined by file system order or explicit nav configuration
+- **nesting_levels**: Supports multiple levels of nesting
+
+**Structure**:
+- Top-level items appear in main sidebar
+- Nested items appear as expandable sections
+- Order can be explicit (nav config) or implicit (directory structure)
+
+## File System Structure
+
+### Source Files (docs/)
+
+```
+docs/
+├── index.md              # Homepage
+├── README.md             # Documentation overview (optional)
+├── specs/                # Specifications directory
+│   ├── 001-init-command/
+│   └── 002-docs-site-infrastructure/
+├── ideas/                # Ideas directory
+│   ├── commands/
+│   └── core/
+└── [other-docs].md       # Additional documentation files
+```
+
+### Generated Files (site/)
+
+```
+site/                     # Generated static site (gitignored)
+├── index.html
+├── specs/
+│   ├── 001-init-command/
+│   │   └── index.html
+│   └── 002-docs-site-infrastructure/
+│       └── index.html
+├── ideas/
+│   ├── commands/
+│   │   └── index.html
+│   └── core/
+│       └── index.html
+├── search/
+│   └── search_index.json # Search index
+└── assets/               # CSS, JS, images
+```
+
+## State Transitions
+
+### Site Generation Process
+
+1. **Source State**: Markdown files in docs/ directory
+2. **Configuration Load**: Read and validate mkdocs.yml
+3. **Processing**: MkDocs processes Markdown files
+4. **Generation**: HTML files generated in site/ directory
+5. **Index Creation**: Search index generated
+6. **Complete State**: Static site ready for viewing/deployment
+
+### Local Development Workflow
+
+1. **Start Server**: `just docs-serve` → MkDocs dev server starts
+2. **File Change**: User edits Markdown file
+3. **Auto-reload**: MkDocs detects change and regenerates
+4. **Browser Refresh**: Browser shows updated content
+
+## Notes
+
+- No database or persistent storage required
+- All state is file-based (source Markdown + generated HTML)
+- Configuration is YAML-based (mkdocs.yml)
+- Search index is generated JSON file
+- Site is fully static (no server-side processing)
+

--- a/specs/002-docs-site-infrastructure/plan.md
+++ b/specs/002-docs-site-infrastructure/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Documentation Site Infrastructure
+
+**Branch**: `002-docs-site-infrastructure` | **Date**: 2026-01-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-docs-site-infrastructure/spec.md`
+
+## Summary
+
+Integrate MkDocs with Material theme to transform Markdown documentation into a navigable, searchable documentation website. This is a configuration and integration task - no new code will be written. The implementation involves: (1) adding MkDocs dependencies to the project, (2) creating mkdocs.yml configuration file, (3) organizing documentation files into a docs/ directory structure, (4) adding justfile targets for local development server and site building, and (5) configuring GitHub Pages deployment support.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (existing project requirement)  
+**Primary Dependencies**: mkdocs, mkdocs-material, mkdocs-mermaid2-plugin (for Mermaid diagram support)  
+**Storage**: N/A (static site generation, filesystem-based)  
+**Testing**: N/A (integration task, no code to test)  
+**Target Platform**: Static HTML site (works in all modern browsers, deployable to GitHub Pages)  
+**Project Type**: Single Python project with CLI  
+**Performance Goals**: Site generation completes in under 30 seconds for typical documentation sets (up to 50 files), page loads in under 2 seconds  
+**Constraints**: Must work offline during generation, must produce static site (no server-side code), configuration must be file-based  
+**Scale/Scope**: Support documentation sets with up to 50 files initially, scalable to hundreds of files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Code Quality:**
+- [x] All code will meet production-quality standards (readable, maintainable, error handling)
+  - *N/A: This is an integration task with no new code*
+- [x] Code will be properly structured with clear separation of concerns
+  - *N/A: This is an integration task with no new code*
+- [x] Appropriate documentation will be included for complex behavior
+  - *Configuration files (mkdocs.yml) will include comments explaining structure*
+
+**Minimal Code Generation:**
+- [x] Implementation plan includes ONLY code required by specification
+  - *No code generation planned - only configuration and integration*
+- [x] No speculative features or "nice-to-have" items included
+  - *Plan includes only MkDocs setup, Material theme, Mermaid support, and justfile targets as specified*
+- [x] No premature abstractions or "future-proofing" code planned
+  - *N/A: No code planned*
+- [x] All planned code traces directly to specification requirements
+  - *All configuration and integration tasks map to functional requirements*
+
+**Gang of Four Patterns:**
+- [x] Design identifies which GoF patterns will be used (Command, Strategy, Template Method, State, Observer, Facade, Abstract Factory)
+  - *N/A: Integration task, no design patterns needed*
+
+**Testability:**
+- [x] Code structure enables unit and integration testing
+  - *N/A: No code to test. Manual verification: run `just docs-serve` and verify site loads*
+- [x] Critical paths have corresponding test plans
+  - *Manual verification plan: verify site generation, navigation, search, and deployment work*
+- [x] Test coverage targets are defined (minimum 80% for critical paths)
+  - *N/A: Integration task, manual verification sufficient*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-docs-site-infrastructure/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+# No source code changes - integration only
+# New files to be created:
+mkdocs.yml              # MkDocs configuration
+docs/                    # Documentation source directory
+  index.md              # Site homepage
+  README.md             # (may link to root README or be separate)
+  specs/                # Link/copy specs documentation
+  ideas/                # Link/copy ideas documentation
+  architecture.md       # Architecture documentation (if exists)
+site/                   # Generated site (gitignored, created by mkdocs build)
+  [generated HTML files]
+
+# Modified files:
+pyproject.toml          # Add mkdocs, mkdocs-material, mkdocs-mermaid2-plugin to dependencies
+justfile                # Add docs-serve and docs-build targets
+.gitignore              # Add site/ directory
+```
+
+**Structure Decision**: This is an integration task that adds configuration files and justfile targets. No source code structure changes needed. Documentation will be organized in a `docs/` directory at project root, following MkDocs conventions. The generated site will be output to `site/` directory (standard MkDocs output location).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations - this is a straightforward integration task with no code generation.
+
+## Phase Completion Status
+
+### Phase 0: Research ✅ Complete
+
+- [x] Research questions identified and resolved
+- [x] Technology choices documented (MkDocs, Material theme, Mermaid plugin)
+- [x] Configuration approach determined
+- [x] Justfile target patterns defined
+- [x] GitHub Pages deployment approach documented
+- [x] `research.md` generated with all decisions
+
+### Phase 1: Design & Contracts ✅ Complete
+
+- [x] Data model documented (configuration structures, file system layout)
+- [x] Contracts created:
+  - [x] `contracts/mkdocs-config.md` - MkDocs configuration contract
+  - [x] `contracts/justfile-targets.md` - Justfile targets contract
+- [x] `data-model.md` generated
+- [x] `quickstart.md` generated with setup and usage instructions
+- [x] Constitution check re-evaluated (all items pass)
+
+### Phase 2: Tasks
+
+**Status**: Pending `/speckit.tasks` command
+
+Phase 2 will break down the implementation into concrete tasks for:
+1. Adding dependencies to pyproject.toml
+2. Creating mkdocs.yml configuration
+3. Setting up docs/ directory structure
+4. Adding justfile targets
+5. Updating .gitignore
+6. Testing and verification
+
+## Next Steps
+
+The plan is complete through Phase 1. Ready for `/speckit.tasks` to create the task breakdown for implementation.

--- a/specs/002-docs-site-infrastructure/quickstart.md
+++ b/specs/002-docs-site-infrastructure/quickstart.md
@@ -1,0 +1,138 @@
+# Quickstart: Documentation Site Infrastructure
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15
+
+## Overview
+
+This quickstart guide explains how to set up and use the MkDocs documentation site infrastructure for the Lily project.
+
+## Prerequisites
+
+- Python 3.13+ installed
+- `uv` package manager installed
+- Project dependencies synced
+
+## Setup Steps
+
+### 1. Install Documentation Dependencies
+
+```bash
+uv sync --group docs
+```
+
+This installs:
+- `mkdocs` - Documentation site generator
+- `mkdocs-material` - Material theme for MkDocs
+- `mkdocs-mermaid2-plugin` - Mermaid diagram support
+
+### 2. Verify Configuration
+
+Ensure `mkdocs.yml` exists at project root with proper configuration (see contracts/mkdocs-config.md for details).
+
+### 3. Organize Documentation
+
+Ensure `docs/` directory exists with:
+- `index.md` - Site homepage
+- `specs/` - Specifications directory (can link to root specs/)
+- `ideas/` - Ideas directory (can link to root ideas/)
+- Any other documentation files
+
+### 4. Test Local Development Server
+
+```bash
+just docs-serve
+```
+
+Open http://127.0.0.1:8000 in your browser. You should see:
+- Site homepage
+- Sidebar navigation
+- Search functionality
+- Dark mode toggle
+
+### 5. Build Static Site
+
+```bash
+just docs-build
+```
+
+This generates the static site in `site/` directory, ready for deployment.
+
+## Common Workflows
+
+### Adding New Documentation
+
+1. Create or edit Markdown file in `docs/` directory
+2. If using `just docs-serve`, changes appear automatically
+3. If building manually, run `just docs-build` after changes
+
+### Adding Mermaid Diagrams
+
+In any Markdown file, use code blocks with `mermaid` language:
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B[Process]
+    B --> C[End]
+```
+````
+
+### Customizing Navigation
+
+Edit `mkdocs.yml` and add/update the `nav` section:
+
+```yaml
+nav:
+  - Home: index.md
+  - Specs: specs/
+  - Ideas: ideas/
+  - New Section: new-section.md
+```
+
+### Deploying to GitHub Pages
+
+**Option 1: Using mkdocs gh-deploy**
+```bash
+uv run mkdocs gh-deploy
+```
+
+**Option 2: Manual Deployment**
+1. Run `just docs-build`
+2. Copy contents of `site/` to `gh-pages` branch
+3. Push to GitHub
+
+## Troubleshooting
+
+### "mkdocs: command not found"
+
+**Solution**: Run `uv sync --group docs` to install dependencies
+
+### "Configuration file not found"
+
+**Solution**: Ensure `mkdocs.yml` exists at project root
+
+### "docs/ directory not found"
+
+**Solution**: Create `docs/` directory with at least `index.md`
+
+### Site not updating after file changes
+
+**Solution**: 
+- Check that `just docs-serve` is running
+- Verify file is saved
+- Check browser console for errors
+
+### Mermaid diagrams not rendering
+
+**Solution**:
+- Verify `mkdocs-mermaid2-plugin` is installed
+- Check that plugin is listed in `mkdocs.yml` plugins section
+- Ensure diagram syntax is correct
+
+## Next Steps
+
+- Review [mkdocs.yml configuration contract](./contracts/mkdocs-config.md)
+- Review [justfile targets contract](./contracts/justfile-targets.md)
+- See [data model](./data-model.md) for structure details
+- Check [research](./research.md) for design decisions

--- a/specs/002-docs-site-infrastructure/research.md
+++ b/specs/002-docs-site-infrastructure/research.md
@@ -1,0 +1,180 @@
+# Research: Documentation Site Infrastructure
+
+**Feature**: Documentation Site Infrastructure  
+**Date**: 2026-01-15  
+**Phase**: 0 - Research
+
+## Research Questions
+
+### 1. MkDocs Installation and Dependency Management
+
+**Question**: How should MkDocs and its plugins be added to a Python project using uv/pyproject.toml?
+
+**Decision**: Add MkDocs dependencies to `pyproject.toml` in a new dependency group called `docs` to keep documentation dependencies separate from runtime dependencies.
+
+**Rationale**: 
+- Keeps documentation tooling separate from application dependencies
+- Allows users to install docs dependencies only when needed: `uv sync --group docs`
+- Follows Python packaging best practices for optional dependencies
+- Compatible with uv dependency management
+
+**Alternatives considered**:
+- Adding to main dependencies: Rejected because docs tools aren't needed for application runtime
+- Separate requirements.txt: Rejected because project uses pyproject.toml for dependency management
+
+**Implementation**:
+```toml
+[dependency-groups]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocs-mermaid2-plugin>=1.1.0",
+]
+```
+
+### 2. MkDocs Configuration Structure
+
+**Question**: What is the optimal mkdocs.yml configuration structure for this project's documentation needs?
+
+**Decision**: Use a minimal mkdocs.yml with Material theme, search enabled, dark mode support, and Mermaid plugin configured. Navigation structure will mirror the docs/ directory organization.
+
+**Rationale**:
+- Minimal configuration aligns with project preference for "no ceremony"
+- Material theme provides all required features (search, dark mode, modern appearance)
+- Directory-based navigation is simpler than manual nav configuration
+- Mermaid plugin enables diagram rendering as specified
+
+**Alternatives considered**:
+- Manual navigation configuration: Rejected because directory-based is simpler and easier to maintain
+- Custom theme: Rejected because Material theme meets all requirements without customization overhead
+
+**Key Configuration Elements**:
+- Site name and description from project metadata
+- Material theme with dark mode toggle enabled
+- Search functionality enabled (default in Material)
+- Mermaid plugin for diagram support
+- Directory-based navigation (nav will auto-populate from docs/ structure)
+
+### 3. Documentation Directory Structure
+
+**Question**: How should existing documentation files be organized in the docs/ directory?
+
+**Decision**: Create a docs/ directory with:
+- `index.md` as the site homepage (can link to or incorporate README.md content)
+- `specs/` subdirectory (symlink or copy from root specs/)
+- `ideas/` subdirectory (symlink or copy from root ideas/)
+- Additional architecture/design docs as needed
+
+**Rationale**:
+- Follows MkDocs convention of docs/ as source directory
+- Preserves existing documentation organization
+- Allows incremental addition of new documentation
+- Symlinks or copies maintain connection to source files
+
+**Alternatives considered**:
+- Moving all docs to docs/: Rejected because it would disrupt existing project structure
+- Keeping docs at root: Rejected because MkDocs expects docs/ directory by default
+- Single flat structure: Rejected because hierarchical organization is clearer
+
+### 4. Justfile Targets for MkDocs
+
+**Question**: What justfile targets are needed for documentation site development?
+
+**Decision**: Create two justfile targets:
+- `docs-serve`: Start local development server (mkdocs serve)
+- `docs-build`: Build static site (mkdocs build)
+
+**Rationale**:
+- `docs-serve` enables local development with live reload
+- `docs-build` creates production-ready static site for deployment
+- Follows standard MkDocs workflow patterns
+- Integrates with existing justfile structure
+
+**Alternatives considered**:
+- Single target with flags: Rejected because separate targets are clearer and more intuitive
+- Additional deployment target: Deferred - GitHub Pages deployment can use mkdocs gh-deploy or be handled via CI/CD
+
+**Implementation**:
+```just
+# Serve documentation site locally
+docs-serve:
+    uv run mkdocs serve
+
+# Build documentation site
+docs-build:
+    uv run mkdocs build
+```
+
+### 5. Mermaid Diagram Support
+
+**Question**: How should Mermaid diagrams be configured in MkDocs?
+
+**Decision**: Use mkdocs-mermaid2-plugin with default configuration. Diagrams will be written in Markdown code blocks with `mermaid` language identifier.
+
+**Rationale**:
+- mkdocs-mermaid2-plugin is the recommended plugin for Material theme
+- Standard Markdown code block syntax is familiar and easy to use
+- Default configuration is sufficient for initial needs
+- Can be extended later if needed
+
+**Alternatives considered**:
+- mkdocs-mermaid-plugin (older): Rejected because mkdocs-mermaid2-plugin is actively maintained and recommended
+- Custom Mermaid integration: Rejected because plugin provides all needed functionality
+
+**Configuration**:
+```yaml
+plugins:
+  - search
+  - mermaid2
+```
+
+### 6. GitHub Pages Deployment Configuration
+
+**Question**: How should the site be configured for GitHub Pages deployment?
+
+**Decision**: Configure mkdocs.yml with site_url and repo_url for GitHub Pages. Use mkdocs gh-deploy command or GitHub Actions for deployment. Add site/ directory to .gitignore.
+
+**Rationale**:
+- site_url enables proper absolute URLs in generated site
+- repo_url enables "Edit on GitHub" links
+- site/ directory should be gitignored (generated content)
+- Deployment can be manual (gh-deploy) or automated (GitHub Actions)
+
+**Alternatives considered**:
+- Committing site/ directory: Rejected because generated content shouldn't be version controlled
+- Manual deployment only: Accepted as initial approach, can add GitHub Actions later if needed
+
+**Configuration**:
+```yaml
+site_url: https://[username].github.io/lily/
+repo_url: https://github.com/[username]/lily
+```
+
+### 7. Site Output Directory
+
+**Question**: Where should MkDocs output the generated site?
+
+**Decision**: Use default `site/` directory at project root. Add to .gitignore.
+
+**Rationale**:
+- Default MkDocs output location is standard and expected
+- Keeps generated files separate from source files
+- Easy to identify and clean up
+- Standard location for deployment tools
+
+**Alternatives considered**:
+- Custom output directory: Rejected because default is sufficient and standard
+- docs/_build/: Rejected because site/ is more standard for MkDocs
+
+## Summary of Decisions
+
+1. **Dependencies**: Add to `[dependency-groups]` in pyproject.toml as `docs` group
+2. **Configuration**: Minimal mkdocs.yml with Material theme, search, dark mode, Mermaid plugin
+3. **Documentation Structure**: docs/ directory with index.md, specs/, ideas/ subdirectories
+4. **Justfile Targets**: `docs-serve` and `docs-build` targets
+5. **Mermaid**: Use mkdocs-mermaid2-plugin with default configuration
+6. **GitHub Pages**: Configure site_url and repo_url, use gh-deploy or GitHub Actions
+7. **Output**: Use default `site/` directory, add to .gitignore
+
+All research questions resolved. Ready for Phase 1 design.
+

--- a/specs/002-docs-site-infrastructure/spec.md
+++ b/specs/002-docs-site-infrastructure/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Documentation Site Infrastructure
+
+**Feature Branch**: `002-docs-site-infrastructure`  
+**Created**: 2026-01-15  
+**Status**: Draft  
+**Input**: User description: "we are going to make the site infrastructure. we are using info in @ideas/docs_site.md using mkdocs and material"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Generate Documentation Site from Markdown (Priority: P1)
+
+A user wants to transform their project's Markdown documentation into a clean, navigable website that can be viewed locally or deployed to a hosting service. They have documentation files (architecture docs, specs, guides) in Markdown format and need a system that automatically converts these into a professional documentation site with navigation, search, and modern presentation.
+
+**Why this priority**: This is the core value proposition - converting existing Markdown documentation into a usable website. Without this capability, the feature provides no value.
+
+**Independent Test**: Can be fully tested by running the site generation command with existing Markdown files and verifying a complete, navigable website is produced that can be viewed in a browser.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project contains Markdown documentation files in organized directories, **When** the user runs the site generation command, **Then** a complete documentation website is generated with all Markdown files converted to web pages
+2. **Given** the generated documentation site, **When** a user opens it in a web browser, **Then** they can navigate between pages using a sidebar navigation menu that reflects the documentation structure
+3. **Given** the generated documentation site, **When** a user searches for content, **Then** they receive relevant search results from across all documentation pages
+4. **Given** the generated documentation site, **When** a user views it, **Then** the site displays with a modern, professional appearance including support for dark mode
+5. **Given** Markdown files contain Mermaid diagrams, **When** the site is generated, **Then** diagrams are rendered correctly as interactive visual elements in the web pages
+
+---
+
+### User Story 2 - Customize Site Appearance and Structure (Priority: P2)
+
+A user wants to configure the documentation site's appearance, navigation structure, and metadata to match their project's needs and branding preferences.
+
+**Why this priority**: While the default configuration should work well, users need the ability to customize site title, navigation order, theme settings, and other presentation aspects to align with their project identity.
+
+**Independent Test**: Can be fully tested by modifying configuration files and regenerating the site, then verifying that changes are reflected in the generated website.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user wants to customize the site title and description, **When** they modify the configuration file, **Then** the generated site displays the custom title and metadata
+2. **Given** a user wants to reorder navigation items, **When** they update the configuration, **Then** the sidebar navigation reflects the new order in the generated site
+3. **Given** a user wants to enable or disable specific features (search, dark mode, etc.), **When** they configure these options, **Then** the generated site includes or excludes these features accordingly
+4. **Given** a user wants to add custom styling or branding, **When** they provide custom assets or configuration, **Then** the generated site incorporates these customizations
+
+---
+
+### User Story 3 - Deploy Documentation Site (Priority: P2)
+
+A user wants to publish their documentation site to a hosting service (such as GitHub Pages) so that team members and stakeholders can access it via a URL.
+
+**Why this priority**: While local viewing is valuable, the ability to share documentation via a hosted URL is essential for collaboration and stakeholder access.
+
+**Independent Test**: Can be fully tested by running the deployment command and verifying the site is accessible at the expected URL with all content properly rendered.
+
+**Acceptance Scenarios**:
+
+1. **Given** a documentation site has been generated, **When** the user runs the deployment command, **Then** the site is published to the configured hosting service and accessible via URL
+2. **Given** a user wants to deploy to GitHub Pages, **When** they configure the deployment settings, **Then** the site is automatically built and published to the appropriate GitHub Pages location
+3. **Given** documentation is updated, **When** the user regenerates and redeploys, **Then** the hosted site reflects the latest changes
+
+---
+
+### Edge Cases
+
+- What happens when Markdown files contain syntax errors? → System should either gracefully handle errors (skip problematic files with warnings) or fail with clear error messages indicating which files have issues
+- How does the system handle very large documentation sets (hundreds of files)? → Site generation should complete successfully and the generated site should remain performant with reasonable page load times
+- What happens when configuration files are missing or invalid? → System should provide sensible defaults or fail with clear error messages explaining what configuration is needed
+- How does the system handle special characters or non-ASCII content in Markdown? → All content should be properly encoded and displayed correctly in the generated site
+- What happens when the output directory already contains files from a previous generation? → System should either overwrite cleanly or merge appropriately without leaving orphaned files
+- How does the system behave when documentation files are moved or renamed? → Navigation should update correctly to reflect the new structure, and old links should either redirect or be clearly marked as broken
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST convert Markdown documentation files into a complete, navigable website with HTML pages
+- **FR-002**: System MUST generate a sidebar navigation menu that reflects the hierarchical structure of the documentation
+- **FR-003**: System MUST provide full-text search functionality across all documentation pages in the generated site
+- **FR-004**: System MUST support dark mode display option that users can toggle
+- **FR-005**: System MUST render Mermaid diagrams from Markdown source into interactive visual elements in the web pages
+- **FR-006**: System MUST allow users to configure site metadata (title, description, author, etc.) through configuration files
+- **FR-007**: System MUST allow users to customize navigation structure and ordering through configuration
+- **FR-008**: System MUST support local viewing of the generated site (users can open and navigate the site in their web browser without a server)
+- **FR-009**: System MUST support deployment to hosting services (with GitHub Pages as a primary target)
+- **FR-010**: System MUST preserve Markdown formatting (headers, lists, code blocks, links, etc.) in the generated web pages
+- **FR-011**: System MUST handle documentation organized in multiple directories and subdirectories, maintaining the structure in navigation
+- **FR-012**: System MUST provide clear error messages when generation fails, indicating which files or configuration caused the issue
+- **FR-013**: System MUST generate a site that loads pages quickly (within reasonable performance expectations for static sites)
+- **FR-014**: System MUST support incremental updates (regenerating only changed content when possible, though full regeneration is acceptable)
+- **FR-015**: System MUST ensure the generated site works across modern web browsers (Chrome, Firefox, Safari, Edge)
+
+### Key Entities *(include if feature involves data)*
+
+- **Documentation Page**: Represents a single page in the generated documentation site, derived from a Markdown source file. Key attributes include source file path, generated HTML path, page title, navigation position, and content.
+- **Navigation Structure**: Represents the hierarchical organization of documentation pages in the sidebar menu. Key attributes include page order, nesting levels, section groupings, and display labels.
+- **Site Configuration**: Represents user-defined settings that control site generation, appearance, and behavior. Key attributes include site title, description, navigation structure, theme preferences, and deployment settings.
+- **Generated Site**: Represents the complete output of the site generation process. Key attributes include output directory location, total pages generated, search index, and deployment status.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can generate a complete documentation site from Markdown files in under 30 seconds for typical documentation sets (up to 50 files)
+- **SC-002**: 100% of valid Markdown files are successfully converted to web pages with all formatting preserved (headers, lists, code blocks, links render correctly)
+- **SC-003**: Generated sites provide search functionality that returns relevant results for user queries within 1 second
+- **SC-004**: Users can navigate between any two pages in the documentation site using sidebar navigation in 2 clicks or fewer
+- **SC-005**: Generated sites load initial page in under 2 seconds on standard broadband connections
+- **SC-006**: Users can successfully deploy documentation sites to GitHub Pages with a single command execution
+- **SC-007**: Generated sites are accessible and functional across all target browsers (Chrome, Firefox, Safari, Edge) with 100% feature parity
+- **SC-008**: Mermaid diagrams render correctly in 100% of cases where valid Mermaid syntax is provided in source Markdown
+
+## Assumptions
+
+- Users have Markdown documentation files already created in their project
+- Users have write permissions to create output directories for generated sites
+- Users have internet access when deploying to hosting services (for GitHub Pages deployment)
+- Documentation files follow standard Markdown syntax conventions
+- Users are familiar with basic Markdown formatting
+- The project structure includes organized directories for documentation files
+- Users want a static site (no server-side processing required for viewing)
+
+## Dependencies
+
+- Markdown parsing and conversion capabilities
+- File system operations for reading source files and writing generated output
+- Configuration file parsing and validation
+- Deployment integration with hosting services (GitHub Pages API or similar)
+
+## Constraints
+
+- Site generation must work offline (no external API calls required during generation, except for deployment)
+- Generated sites must be static (no server-side code execution required for viewing)
+- Configuration must be file-based (not interactive prompts during generation)
+- Site generation should be deterministic (same inputs produce same outputs)
+- The system must not modify source Markdown files (read-only access to sources)
+

--- a/specs/002-docs-site-infrastructure/tasks.md
+++ b/specs/002-docs-site-infrastructure/tasks.md
@@ -1,0 +1,209 @@
+# Implementation Tasks: Documentation Site Infrastructure
+
+**Feature**: Documentation Site Infrastructure  
+**Branch**: `002-docs-site-infrastructure`  
+**Date**: 2026-01-15  
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+## Summary
+
+This document breaks down the implementation of MkDocs documentation site infrastructure into actionable tasks. This is an **integration task** with **no code generation** - all work involves configuration files, directory setup, and justfile targets.
+
+**Total Tasks**: 23  
+**Setup (Phase 1)**: 3 tasks  
+**Foundational (Phase 2)**: 4 tasks  
+**User Story 1 (P1)**: 8 tasks  
+**User Story 2 (P2)**: 3 tasks  
+**User Story 3 (P2)**: 2 tasks  
+**Polish**: 3 tasks
+
+## Implementation Strategy
+
+**MVP Scope**: Complete User Story 1 (Generate Documentation Site from Markdown) - this delivers the core value proposition and enables all other stories.
+
+**Incremental Delivery**:
+1. **Phase 1-2**: Setup and foundational configuration (enables all stories)
+2. **Phase 3**: User Story 1 - Core site generation (MVP)
+3. **Phase 4**: User Story 2 - Customization (enhancement)
+4. **Phase 5**: User Story 3 - Deployment (enhancement)
+5. **Final**: Polish and verification
+
+## Dependencies
+
+**Story Completion Order**:
+- **User Story 1** (P1) must complete first - it provides the core functionality
+- **User Story 2** (P2) can start after User Story 1 - it enhances configuration
+- **User Story 3** (P2) requires User Story 1 - it deploys the generated site
+- **Polish** requires all user stories - it adds convenience features
+
+**Parallel Opportunities**:
+- Tasks T001-T003 can be done in parallel (different files)
+- Tasks T004-T005 can be done in parallel (different files)
+- Tasks T006-T007 can be done in parallel (different files)
+- Tasks T011-T012 can be done in parallel (different files)
+
+---
+
+## Phase 1: Setup
+
+**Goal**: Prepare project for MkDocs integration by adding dependencies and creating directory structure.
+
+**Independent Test**: After Phase 1, running `uv sync --group docs` should install MkDocs dependencies, and `docs/` directory should exist with basic structure.
+
+### Tasks
+
+- [x] T001 Add MkDocs dependencies to pyproject.toml dependency groups in pyproject.toml
+- [x] T002 [P] Create docs/ directory structure in docs/
+- [x] T003 [P] Create docs/index.md homepage file in docs/index.md
+
+---
+
+## Phase 2: Foundational Configuration
+
+**Goal**: Create basic MkDocs configuration file that enables site generation with Material theme, search, and Mermaid support.
+
+**Independent Test**: After Phase 2, `mkdocs.yml` exists with valid configuration. Running `uv run mkdocs build` should succeed (even if docs/ is mostly empty).
+
+### Tasks
+
+- [x] T004 Create mkdocs.yml configuration file with site metadata in mkdocs.yml
+- [x] T005 [P] Configure Material theme with dark mode support in mkdocs.yml
+- [x] T006 [P] Configure search plugin in mkdocs.yml
+- [x] T007 [P] Configure mermaid2 plugin in mkdocs.yml
+
+---
+
+## Phase 3: User Story 1 - Generate Documentation Site from Markdown (P1)
+
+**Goal**: Enable users to transform Markdown documentation into a navigable website with search, dark mode, and Mermaid diagram support.
+
+**Independent Test**: After Phase 3, users can:
+1. Run `just docs-build` to generate a complete static site
+2. Run `just docs-serve` to view site locally with live reload
+3. Navigate between pages using sidebar navigation
+4. Search for content across all pages
+5. Toggle dark mode
+6. View Mermaid diagrams rendered correctly
+
+**Acceptance Criteria** (from spec):
+- ✅ All Markdown files converted to HTML pages
+- ✅ Sidebar navigation reflects documentation structure
+- ✅ Full-text search works across all pages
+- ✅ Dark mode toggle functions
+- ✅ Mermaid diagrams render correctly
+
+### Tasks
+
+- [x] T008 [US1] Organize existing documentation into docs/ directory structure in docs/
+- [x] T009 [US1] Create navigation structure linking specs/ and ideas/ in mkdocs.yml
+- [x] T010 [US1] Add docs-serve justfile target for local development server in justfile
+- [x] T011 [US1] [P] Add docs-build justfile target for static site generation in justfile
+- [x] T012 [US1] [P] Verify site generation produces complete navigable website (manual verification)
+- [x] T013 [US1] Verify search functionality works across all pages (manual verification)
+- [x] T014 [US1] Verify dark mode toggle functions correctly (manual verification)
+- [x] T015 [US1] Verify Mermaid diagrams render correctly (manual verification - add test diagram if needed)
+
+---
+
+## Phase 4: User Story 2 - Customize Site Appearance and Structure (P2)
+
+**Goal**: Enable users to customize site title, description, navigation order, and theme settings through configuration.
+
+**Independent Test**: After Phase 4, users can modify `mkdocs.yml` to change site title, description, navigation order, and theme colors, and see changes reflected in generated site.
+
+**Acceptance Criteria** (from spec):
+- ✅ Site title and description customizable
+- ✅ Navigation order configurable
+- ✅ Theme features (search, dark mode) can be enabled/disabled
+- ✅ Custom styling/branding can be added
+
+### Tasks
+
+- [x] T016 [US2] Add site_name and site_description configuration with project-specific values in mkdocs.yml
+- [x] T017 [US2] Document navigation customization options in mkdocs.yml (add comments)
+- [x] T018 [US2] Verify customization changes are reflected in generated site (manual verification)
+
+---
+
+## Phase 5: User Story 3 - Deploy Documentation Site (P2)
+
+**Goal**: Enable users to deploy documentation site to GitHub Pages.
+
+**Independent Test**: After Phase 5, users can configure GitHub Pages deployment settings and deploy site using `mkdocs gh-deploy` or similar method.
+
+**Acceptance Criteria** (from spec):
+- ✅ Site can be deployed to GitHub Pages
+- ✅ Deployment configuration is documented
+- ✅ Deployed site is accessible via URL
+
+### Tasks
+
+- [x] T019 [US3] Add site_url and repo_url configuration for GitHub Pages in mkdocs.yml
+- [x] T020 [US3] Document GitHub Pages deployment process in quickstart.md or README
+
+---
+
+## Final Phase: Polish & Cross-Cutting Concerns
+
+**Goal**: Add convenience features, verify .gitignore, and ensure all requirements are met.
+
+**Independent Test**: After Final Phase, all justfile targets work, generated site is gitignored, and complete feature verification passes.
+
+### Tasks
+
+- [x] T021 Verify site/ directory is in .gitignore (check existing entry)
+- [x] T022 Add optional docs-clean justfile target for removing generated site (optional enhancement)
+- [x] T023 Complete feature verification: test all acceptance scenarios from spec (manual verification)
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1 Tasks (T008-T015)
+
+**Parallel Group 1** (can run simultaneously):
+- T011: Add docs-build target (justfile)
+- T012: Verify site generation (manual)
+
+**Parallel Group 2** (can run simultaneously):
+- T013: Verify search (manual)
+- T014: Verify dark mode (manual)
+- T015: Verify Mermaid (manual)
+
+### Setup Tasks (T001-T003)
+
+**Parallel Group** (can run simultaneously):
+- T002: Create docs/ directory
+- T003: Create docs/index.md
+
+### Configuration Tasks (T004-T007)
+
+**Parallel Group** (can run simultaneously):
+- T005: Configure Material theme
+- T006: Configure search plugin
+- T007: Configure mermaid2 plugin
+
+---
+
+## Task Completion Checklist
+
+Before marking feature complete, verify:
+
+- [ ] All Phase 1-2 tasks complete (setup and foundational config)
+- [ ] User Story 1 fully implemented and tested (core functionality)
+- [ ] User Story 2 fully implemented and tested (customization)
+- [ ] User Story 3 fully implemented and tested (deployment)
+- [ ] All justfile targets work correctly
+- [ ] Generated site is gitignored
+- [ ] All acceptance scenarios from spec pass
+- [ ] Quickstart guide is accurate
+
+---
+
+## Notes
+
+- **No code generation**: All tasks involve configuration, file creation, and integration only
+- **Manual verification**: Testing is done by running commands and verifying output in browser
+- **Incremental delivery**: Each phase builds on previous phases
+- **MVP**: Phase 3 (User Story 1) delivers core value and can be used independently
+

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,92 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -94,12 +180,67 @@ wheels = [
 ]
 
 [[package]]
+name = "editorconfig"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
 ]
 
 [[package]]
@@ -158,6 +299,11 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-mermaid2-plugin" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -170,6 +316,20 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.5.0" },
+    { name = "mkdocs-material", specifier = ">=9.5.0" },
+    { name = "mkdocs-mermaid2-plugin", specifier = ">=1.1.0" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
 ]
 
 [[package]]
@@ -185,12 +345,159 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/e2/2ffc356cd72f1473d07c7719d82a8f2cbd261666828614ecb95b12169f41/mkdocs_material-9.7.1.tar.gz", hash = "sha256:89601b8f2c3e6c6ee0a918cc3566cb201d40bf37c3cd3c2067e26fadb8cce2b8", size = 4094392, upload-time = "2025-12-18T09:49:00.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl", hash = "sha256:3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c", size = 9297166, upload-time = "2025-12-18T09:48:56.664Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-mermaid2-plugin"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "jsbeautifier" },
+    { name = "mkdocs" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/6d/308f443a558b6a97ce55782658174c0d07c414405cfc0a44d36ad37e36f9/mkdocs_mermaid2_plugin-1.2.3.tar.gz", hash = "sha256:fb6f901d53e5191e93db78f93f219cad926ccc4d51e176271ca5161b6cc5368c", size = 16220, upload-time = "2025-10-17T19:38:53.047Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl", hash = "sha256:33f60c582be623ed53829a96e19284fc7f1b74a1dbae78d4d2e47fe00c3e190d", size = 17299, upload-time = "2025-10-17T19:38:51.874Z" },
 ]
 
 [[package]]
@@ -239,12 +546,30 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/bb8e495d5262bfec41ab5cb18f522f1012933347fb5d9e62452d446baca2/pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d", size = 130841, upload-time = "2026-01-09T15:46:46.009Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c", size = 55021, upload-time = "2026-01-09T15:46:44.652Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
 ]
 
 [[package]]
@@ -334,6 +659,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/35/e3814a5b7df295df69d035cfb8aab78b2967cdf11fcfae7faed726b66664/pymdown_extensions-10.20.tar.gz", hash = "sha256:5c73566ab0cf38c6ba084cb7c5ea64a119ae0500cce754ccb682761dfea13a52", size = 852774, upload-time = "2025-12-31T19:59:42.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/10/47caf89cbb52e5bb764696fd52a8c591a2f0e851a93270c05a17f36000b5/pymdown_extensions-10.20-py3-none-any.whl", hash = "sha256:ea9e62add865da80a271d00bfa1c0fa085b20d133fb3fc97afdc88e682f60b2f", size = 268733, upload-time = "2025-12-31T19:59:40.652Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -364,6 +702,81 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -377,12 +790,39 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/23/adf3796d740536d63a6fbda113d07e60c734b6ed5d3058d1e47fc0495e47/soupsieve-2.8.1.tar.gz", hash = "sha256:4cf733bc50fa805f5df4b8ef4740fc0e0fa6218cf3006269afd3f9d6d80fd350", size = 117856, upload-time = "2025-12-18T13:50:34.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f3/b67d6ea49ca9154453b6d70b34ea22f3996b9fa55da105a79d8732227adc/soupsieve-2.8.1-py3-none-any.whl", hash = "sha256:a11fe2a6f3d76ab3cf2de04eb339c1be5b506a8a47f2ceb6d139803177f85434", size = 36710, upload-time = "2025-12-18T13:50:33.267Z" },
 ]
 
 [[package]]
@@ -419,4 +859,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
…theme

- Add MkDocs dependencies (mkdocs, mkdocs-material, mkdocs-mermaid2-plugin) to pyproject.toml docs group
- Create mkdocs.yml configuration with Material theme, search, dark mode, and Mermaid support
- Set up docs/ directory structure with organized documentation
- Add justfile targets: docs-serve, docs-build, docs-clean
- Create comprehensive documentation pages:
  - Getting Started guide
  - Architecture documentation
  - Commands documentation (init, status)
  - Deployment guide
  - Mermaid diagram test page
- Organize existing specs and ideas into docs/ structure
- Configure navigation structure in mkdocs.yml
- Verify site/ directory is properly gitignored
- Complete all 23 implementation tasks from spec 002-docs-site-infrastructure

The documentation site is now fully functional and can be served locally with 'just docs-serve' or built for deployment with 'just docs-build'.