### PR TITLE
feat(runtime): stabilize command envelope, persistence, and session lanes

### DIFF
--- a/docs/dev/later_backlog.md
+++ b/docs/dev/later_backlog.md
@@ -2,6 +2,8 @@
 
 Purpose: track important deferred items while we keep Slice 001 narrow.
 
+Priority source of truth: `docs/dev/roadmap.md`.
+
 ## Core Runtime
 
 - [ ] Persist session state to disk (including `skill_snapshot`) so sessions can survive process restarts.
@@ -15,6 +17,7 @@ Purpose: track important deferred items while we keep Slice 001 narrow.
 - [ ] Add optional user skills root and include it in precedence (`workspace > user > bundled`).
 - [ ] Add skill alias commands from frontmatter `command` with collision checks.
 - [ ] Add `tool_dispatch` execution path with strict `command_tool` validation.
+- [ ] Add deterministic tool discovery/registration so skills can introduce their own tools without manual runtime wiring.
 - [ ] Add richer loader diagnostics output surface for malformed/ineligible skills.
 - [ ] Remove temporary `if skill_name == "echo"` branch in backend and make behavior sourcing skill-driven.
 - [ ] Load and pass `SKILL.md` body/instructions to execution layer so orchestration is not hardcoded per skill.
@@ -49,6 +52,7 @@ Purpose: track important deferred items while we keep Slice 001 narrow.
 - [ ] Add schema version field to persisted session payloads.
 - [ ] Add migration stubs for future session schema changes.
 - [ ] Define canonical normalization rules for skill names and command aliases.
+- [ ] Add typed skill I/O contracts (validated input/output schemas) for deterministic skill execution.
 
 ## Persona And Context
 

--- a/docs/dev/punchlist.md
+++ b/docs/dev/punchlist.md
@@ -1,0 +1,48 @@
+# Lily Punchlist
+
+Purpose: concrete engineering checklist to get Lily to a solid, usable state.
+
+## Priority 5 (Do First)
+
+- [x] Remove prototype hardcoding (`echo`)
+  - [x] Remove `if request.skill_name == "echo"` behavior in `src/lily/runtime/llm_backend/langchain_adapter.py`
+  - [x] Pass skill artifact instructions/body into LLM request path
+  - [x] Ensure no skill-name-specific runtime branches remain
+
+- [x] Implement real `tool_dispatch`
+  - [x] Replace placeholder in `src/lily/runtime/executors/tool_dispatch.py`
+  - [x] Add strict `command_tool` validation and deterministic error outputs
+  - [x] Wire dispatch path through runtime facade/executor setup
+
+- [ ] Expand core command surface
+  - [x] Add `/reload_skills`
+  - [ ] Add `/help <skill>`
+  - [ ] Add `/agent <name>`
+  - [ ] Add skill alias commands from frontmatter `command` with built-in collision protection
+
+- [ ] Standardize command envelope
+  - [ ] Extend `CommandResult` to include `code` and `data` in addition to `status` and `message`
+  - [ ] Update handlers/executors to return stable machine-readable outputs
+  - [ ] Update CLI rendering path accordingly
+
+- [ ] Add session persistence + reload semantics
+  - [ ] Persist session state to disk (`session_id`, `active_agent`, `model_config`, `skill_snapshot`, conversation)
+  - [ ] Add session schema version field and migration stub path
+  - [ ] Define recovery behavior for missing/corrupt persisted state
+
+- [ ] Add per-session execution serialization
+  - [ ] Introduce a per-session queue/lane boundary for command + execution flow
+  - [ ] Prevent interleaving/race issues under concurrent inputs
+
+- [ ] Add reliability coverage
+  - [ ] Restart simulation tests (session restore + snapshot continuity)
+  - [ ] Snapshot drift tests (filesystem mutation does not alter current session snapshot)
+  - [ ] Concurrency/serialization tests
+
+## Priority 4 (Next Elevation)
+
+- [ ] Typed skill I/O contracts
+  - [ ] Add optional input/output schema fields to skill metadata
+  - [ ] Validate input pre-execution and output post-execution
+  - [ ] Return deterministic validation errors
+  - [ ] Prove with at least two skills end-to-end

--- a/docs/dev/punchlist.md
+++ b/docs/dev/punchlist.md
@@ -14,11 +14,10 @@ Purpose: concrete engineering checklist to get Lily to a solid, usable state.
   - [x] Add strict `command_tool` validation and deterministic error outputs
   - [x] Wire dispatch path through runtime facade/executor setup
 
-- [ ] Expand core command surface
+- [x] Expand core command surface
   - [x] Add `/reload_skills`
   - [x] Add `/help <skill>`
-  - [ ] Add `/agent <name>`
-  - [ ] Add skill alias commands from frontmatter `command` with built-in collision protection
+  - [x] Add skill alias commands from frontmatter `command` with built-in collision protection
 
 - [ ] Standardize command envelope
   - [ ] Extend `CommandResult` to include `code` and `data` in addition to `status` and `message`
@@ -41,6 +40,7 @@ Purpose: concrete engineering checklist to get Lily to a solid, usable state.
 
 ## Priority 4 (Next Elevation)
 
+- [ ] Add `/agent <name>` (deferred until real agents/persona subsystem exists)
 - [ ] Typed skill I/O contracts
   - [ ] Add optional input/output schema fields to skill metadata
   - [ ] Validate input pre-execution and output post-execution

--- a/docs/dev/punchlist.md
+++ b/docs/dev/punchlist.md
@@ -19,10 +19,10 @@ Purpose: concrete engineering checklist to get Lily to a solid, usable state.
   - [x] Add `/help <skill>`
   - [x] Add skill alias commands from frontmatter `command` with built-in collision protection
 
-- [ ] Standardize command envelope
-  - [ ] Extend `CommandResult` to include `code` and `data` in addition to `status` and `message`
-  - [ ] Update handlers/executors to return stable machine-readable outputs
-  - [ ] Update CLI rendering path accordingly
+- [x] Standardize command envelope
+  - [x] Extend `CommandResult` to include `code` and `data` in addition to `status` and `message`
+  - [x] Update handlers/executors to return stable machine-readable outputs
+  - [x] Update CLI rendering path accordingly
 
 - [x] Add session persistence + reload semantics
   - [x] Persist session state to disk (`session_id`, `active_agent`, `model_config`, `skill_snapshot`, conversation)
@@ -33,10 +33,10 @@ Purpose: concrete engineering checklist to get Lily to a solid, usable state.
   - [x] Introduce a per-session queue/lane boundary for command + execution flow
   - [x] Prevent interleaving/race issues under concurrent inputs
 
-- [ ] Add reliability coverage
-  - [ ] Restart simulation tests (session restore + snapshot continuity)
-  - [ ] Snapshot drift tests (filesystem mutation does not alter current session snapshot)
-  - [ ] Concurrency/serialization tests
+- [x] Add reliability coverage
+  - [x] Restart simulation tests (session restore + snapshot continuity)
+  - [x] Snapshot drift tests (filesystem mutation does not alter current session snapshot)
+  - [x] Concurrency/serialization tests
 
 ## Priority 4 (Next Elevation)
 

--- a/docs/dev/punchlist.md
+++ b/docs/dev/punchlist.md
@@ -16,7 +16,7 @@ Purpose: concrete engineering checklist to get Lily to a solid, usable state.
 
 - [ ] Expand core command surface
   - [x] Add `/reload_skills`
-  - [ ] Add `/help <skill>`
+  - [x] Add `/help <skill>`
   - [ ] Add `/agent <name>`
   - [ ] Add skill alias commands from frontmatter `command` with built-in collision protection
 

--- a/docs/dev/punchlist.md
+++ b/docs/dev/punchlist.md
@@ -24,14 +24,14 @@ Purpose: concrete engineering checklist to get Lily to a solid, usable state.
   - [ ] Update handlers/executors to return stable machine-readable outputs
   - [ ] Update CLI rendering path accordingly
 
-- [ ] Add session persistence + reload semantics
-  - [ ] Persist session state to disk (`session_id`, `active_agent`, `model_config`, `skill_snapshot`, conversation)
-  - [ ] Add session schema version field and migration stub path
-  - [ ] Define recovery behavior for missing/corrupt persisted state
+- [x] Add session persistence + reload semantics
+  - [x] Persist session state to disk (`session_id`, `active_agent`, `model_config`, `skill_snapshot`, conversation)
+  - [x] Add session schema version field and migration stub path
+  - [x] Define recovery behavior for missing/corrupt persisted state
 
-- [ ] Add per-session execution serialization
-  - [ ] Introduce a per-session queue/lane boundary for command + execution flow
-  - [ ] Prevent interleaving/race issues under concurrent inputs
+- [x] Add per-session execution serialization
+  - [x] Introduce a per-session queue/lane boundary for command + execution flow
+  - [x] Prevent interleaving/race issues under concurrent inputs
 
 - [ ] Add reliability coverage
   - [ ] Restart simulation tests (session restore + snapshot continuity)

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -1,0 +1,182 @@
+# Lily Roadmap (Guiding Light)
+
+Purpose: define what we build, in what order, and why.
+
+This roadmap is the source of truth for prioritization.
+If something is not on this list (or not promoted on this list), we do not build it yet.
+
+## Priority Scale
+
+- `5` = Must have for usable Lily (build now)
+- `4` = High value, build soon after core is stable
+- `3` = Important, but can wait
+- `2` = Nice improvement
+- `1` = Interesting idea, optional/experimental
+
+## Core Rule
+
+We focus on `5` features first until Lily is reliably usable for real work.
+No `4/3/2/1` feature should preempt unfinished `5` work unless it unblocks a `5`.
+
+## Dependency Map (Good-Place First)
+
+```mermaid
+flowchart TD
+  G[Goal: Lily is usable and reliable for daily work]
+
+  subgraph F5[Priority 5 Features]
+    F1[Session continuity across restarts]
+    F2["/reload_skills"]
+    F3["/help skill"]
+    F4[Skill aliases]
+    F5_CMD[Direct command skills]
+    F6[Skills run from definitions, not prototypes]
+    F7[Stable machine-readable command responses]
+    F8[Reliable behavior under concurrent input]
+  end
+
+  subgraph S5[Priority 5 System Improvements]
+    S1[Remove prototype-only skill branches]
+    S2["Pass SKILL.md artifact content into runtime"]
+    S3[Strict command_tool validation]
+    S4["Per-session lane/queue serialization"]
+    S5_TESTS[Reliability tests: restart, drift, concurrency]
+  end
+
+  %% Delivery backbone
+  S1 --> F6
+  S2 --> F6
+  S3 --> F5_CMD
+  S4 --> F8
+  S5_TESTS --> G
+
+  %% Feature dependencies
+  F2 --> F4
+  F3 --> F4
+  F4 --> F5_CMD
+  F6 --> F5_CMD
+  F7 --> F5_CMD
+  F1 --> G
+  F5_CMD --> G
+  F8 --> G
+
+  %% Validation loop
+  F1 --> S5_TESTS
+  F5_CMD --> S5_TESTS
+  F8 --> S5_TESTS
+```
+
+Recommended critical path to "good place":
+1. `F2`, `F3`, `F7` (core command usability)
+2. `S1`, `S2` -> `F6` (real skill execution)
+3. `F4` -> `S3` -> `F5` (deterministic direct commands)
+4. `S4` -> `F8` (concurrency reliability)
+5. `F1` + `S5` (restart continuity + confidence gates)
+
+## User Stories (Features List)
+
+| User story | Priority | Why it matters |
+|---|---:|---|
+| As a user, I can continue my session after restart without losing context. | 5 | Daily usability and trust |
+| As a user, I can run `/reload_skills` to refresh available skills when I choose. | 5 | Explicit, deterministic control |
+| As a user, I can run `/help <skill>` to understand what a skill does before using it. | 5 | Discoverability and confidence |
+| As a user, I can invoke common skills by short aliases like `/plan`. | 5 | Faster workflows |
+| As a user, I can trigger direct command skills for high-confidence actions. | 5 | Deterministic operations |
+| As a user, adding a new skill actually works without hidden hardcoded behavior. | 5 | Real extensibility |
+| As a user, command responses are stable and machine-readable. | 5 | Predictable UX + automation |
+| As a user, multiple incoming actions do not create inconsistent results. | 5 | Reliability under load |
+| As a user, I can switch active persona/agent with `/agent <name>`. | 4 | Multi-agent workflows |
+| As a user, I can use my own personal skills in addition to workspace and bundled skills. | 4 | Better customization |
+| As a user, I get clear reasons when a skill is malformed or unavailable. | 4 | Better debugging and trust |
+| As a user, I can inspect run diagnostics/traces when something goes wrong. | 4 | Troubleshooting support |
+| As a user, skills can define typed inputs/outputs so behavior is more deterministic. | 4 | Higher-quality contracts |
+| As a user, skill changes are detected quickly with a clear refresh signal. | 3 | Faster iteration |
+| As a user, unknown commands can offer safe suggestions (without auto-running anything). | 2 | Better UX |
+| As a user, I can reload persona files without restarting (`/reload_persona`). | 2 | Convenience |
+| As a user, I can validate/lint skills before running them. | 2 | Fewer runtime surprises |
+| As a user, I can view replay artifacts for debugging. | 2 | Post-run analysis |
+| As a user, I can install skills from external plugins/registry. | 1 | Ecosystem expansion |
+| As a user, Lily can evolve into multi-channel routing/platform capabilities. | 1 | Long-term expansion |
+
+## Focused Build Order (Only Priority 5)
+
+### Phase A: Usable Core Commands
+
+1. `/reload_skills`
+2. `/help <skill>`
+3. stable machine-readable command responses
+4. skill aliases
+5. direct command skills (deterministic)
+
+Exit criteria:
+- deterministic command behavior
+- deterministic errors
+- no silent fallback
+- aliases and direct command skills fully tested
+
+### Phase B: Real Skill Usability
+
+1. ensure skills run from their own definitions
+2. validate at least two non-prototype skills end-to-end
+3. keep both orchestration and direct-command skill paths consistent
+
+Exit criteria:
+- no prototype-only behavior paths in runtime
+- at least 2 non-prototype skills work through shared contract
+
+### Phase C: Reliability for Daily Use
+
+1. session persistence and reload semantics
+2. reliable per-session concurrency behavior
+3. restart + drift + concurrency reliability validation
+
+Exit criteria:
+- process restart preserves session + snapshot as specified
+- concurrent inputs do not corrupt or reorder session state unexpectedly
+- reliability tests are green
+
+### Phase D: Deterministic Skill Contracts (Priority-4 Elevation)
+
+1. add optional typed I/O schema fields to skill metadata/contracts
+2. validate input before execution and output before returning
+3. add contract tests for schema violations and stable error behavior
+
+Exit criteria:
+- typed skills fail fast with deterministic validation errors
+- tool_dispatch and llm_orchestration both support typed contract checks
+- at least 2 skills use typed I/O end-to-end
+
+## What We Build Right Now
+
+Current active target: **Phase A**.
+
+Until Phase A exits green, new work should be limited to:
+- bug fixes in current v0 runtime
+- work that directly unblocks Phase A items
+
+## System Improvements (Internal Work)
+
+These are not user-facing features. They are required to make Lily robust.
+
+| Improvement | Priority | Enables |
+|---|---:|---|
+| Remove skill-specific prototype branches (for example `echo` special-casing). | 5 | Real extensibility from skill files |
+| Pass skill artifact content (`SKILL.md`) into execution paths. | 5 | Skill-driven behavior |
+| Implement strict `command_tool` validation for direct command skills. | 5 | Deterministic/safe command execution |
+| Add per-session lane/queue serialization primitives. | 5 | Reliable concurrent behavior |
+| Add restart, snapshot drift, and concurrency reliability tests. | 5 | Confidence in core stability |
+| Session persistence schema versioning and migration stubs. | 4 | Safe evolution over time |
+| Structured loader/command/executor trace events. | 4 | Operability and debugging |
+| File-locking strategy for multi-process persistence safety. | 3 | Correctness in advanced deployments |
+
+## How We Use This Document
+
+For every new task:
+1. Map it to a feature in this table.
+2. If it is not mapped, add it with a priority before implementation.
+3. If its priority is lower than unfinished `5` work, it waits.
+4. If we change a priority, update this document in the same PR.
+
+## Change Log
+
+- 2026-02-14: Initial roadmap created as execution guide after Agent Mode v0 completion.

--- a/justfile
+++ b/justfile
@@ -94,3 +94,7 @@ quality-check: format-check lint-check types complexity vulture darglint audit b
 # --- Lighter targets for day-to-day dev ---
 # Recommended while developing: format + lint + types. Fast except mypy; catches most issues.
 quality-dev: format lint types
+
+# Run interactive CLI REPL (slash-command testing)
+repl:
+    uv run lily repl

--- a/skills/add/SKILL.md
+++ b/skills/add/SKILL.md
@@ -1,0 +1,12 @@
+---
+summary: Add two numbers from a simple expression.
+invocation_mode: tool_dispatch
+command_tool: add
+---
+# Add
+
+Compute a sum from user input in the format `<number>+<number>`.
+
+Examples:
+- `2+2`
+- `10.5+1.25`

--- a/skills/add/SKILL.md
+++ b/skills/add/SKILL.md
@@ -1,6 +1,7 @@
 ---
 summary: Add two numbers from a simple expression.
 invocation_mode: tool_dispatch
+command: add
 command_tool: add
 ---
 # Add

--- a/src/lily/cli/cli.py
+++ b/src/lily/cli/cli.py
@@ -84,7 +84,7 @@ def _build_session(
         SessionFactoryConfig(
             bundled_dir=bundled_dir,
             workspace_dir=workspace_dir,
-            reserved_commands={"skills", "skill"},
+            reserved_commands={"skills", "skill", "reload_skills"},
         )
     )
     return factory.create(model_config=ModelConfig(model_name=model_name))

--- a/src/lily/cli/cli.py
+++ b/src/lily/cli/cli.py
@@ -10,6 +10,8 @@ import click
 import typer
 from rich.console import Console
 from rich.logging import RichHandler
+from rich.markdown import Markdown
+from rich.panel import Panel
 
 from lily.commands.types import CommandStatus
 from lily.runtime.facade import RuntimeFacade
@@ -84,7 +86,7 @@ def _build_session(
         SessionFactoryConfig(
             bundled_dir=bundled_dir,
             workspace_dir=workspace_dir,
-            reserved_commands={"skills", "skill", "reload_skills"},
+            reserved_commands={"skills", "skill", "help", "reload_skills"},
         )
     )
     return factory.create(model_config=ModelConfig(model_name=model_name))
@@ -107,9 +109,23 @@ def _render_result(message: str, status: CommandStatus) -> None:
         status: Result status.
     """
     if status == CommandStatus.OK:
-        _CONSOLE.print(message, style="green")
+        _CONSOLE.print(
+            Panel(
+                Markdown(message),
+                title="Lily",
+                border_style="green",
+                expand=True,
+            )
+        )
         return
-    _CONSOLE.print(message, style="bold red")
+    _CONSOLE.print(
+        Panel(
+            message,
+            title="Error",
+            border_style="bold red",
+            expand=True,
+        )
+    )
 
 
 def _execute_once(

--- a/src/lily/commands/handlers/help_skill.py
+++ b/src/lily/commands/handlers/help_skill.py
@@ -9,14 +9,28 @@ from lily.skills.types import SkillEntry
 
 
 def _format_list(values: tuple[str, ...]) -> str:
-    """Render deterministic comma-separated list with fallback."""
+    """Render deterministic comma-separated list with fallback.
+
+    Args:
+        values: Tuple of string values to render.
+
+    Returns:
+        Comma-separated display string or `(none)`.
+    """
     if not values:
         return "(none)"
     return ", ".join(values)
 
 
 def _format_help(entry: SkillEntry) -> str:
-    """Build deterministic human-readable help output for a snapshot skill."""
+    """Build deterministic human-readable help output for a snapshot skill.
+
+    Args:
+        entry: Snapshot skill entry to describe.
+
+    Returns:
+        Markdown text describing the skill.
+    """
     lines = [
         f"# /help {entry.name}",
         "",
@@ -39,21 +53,47 @@ class HelpSkillCommand:
     """Deterministic `/help <skill>` command handler."""
 
     def execute(self, call: CommandCall, session: Session) -> CommandResult:
-        """Render snapshot metadata for one skill without executing it."""
+        """Render snapshot metadata for one skill without executing it.
+
+        Args:
+            call: Parsed command call.
+            session: Session containing the current skill snapshot.
+
+        Returns:
+            Deterministic success/error result.
+        """
         if len(call.args) != 1:
-            return CommandResult.error("Error: /help requires exactly one skill name.")
+            return CommandResult.error(
+                "Error: /help requires exactly one skill name.",
+                code="invalid_args",
+                data={"command": "help"},
+            )
 
         skill_name = call.args[0]
         target = self._find_skill(session, skill_name)
         if target is None:
             return CommandResult.error(
-                f"Error: skill '{skill_name}' not found in snapshot."
+                f"Error: skill '{skill_name}' not found in snapshot.",
+                code="skill_not_found",
+                data={"skill": skill_name},
             )
-        return CommandResult.ok(_format_help(target))
+        return CommandResult.ok(
+            _format_help(target),
+            code="skill_help",
+            data={"skill": target.name},
+        )
 
     @staticmethod
     def _find_skill(session: Session, skill_name: str) -> SkillEntry | None:
-        """Look up exact skill name from current session snapshot."""
+        """Look up exact skill name from current session snapshot.
+
+        Args:
+            session: Session to query.
+            skill_name: Exact skill name.
+
+        Returns:
+            Matching skill entry or None.
+        """
         for entry in session.skill_snapshot.skills:
             if entry.name == skill_name:
                 return entry

--- a/src/lily/commands/handlers/help_skill.py
+++ b/src/lily/commands/handlers/help_skill.py
@@ -1,0 +1,60 @@
+"""Handler for /help <skill>."""
+
+from __future__ import annotations
+
+from lily.commands.parser import CommandCall
+from lily.commands.types import CommandResult
+from lily.session.models import Session
+from lily.skills.types import SkillEntry
+
+
+def _format_list(values: tuple[str, ...]) -> str:
+    """Render deterministic comma-separated list with fallback."""
+    if not values:
+        return "(none)"
+    return ", ".join(values)
+
+
+def _format_help(entry: SkillEntry) -> str:
+    """Build deterministic human-readable help output for a snapshot skill."""
+    lines = [
+        f"# /help {entry.name}",
+        "",
+        f"- `name`: {entry.name}",
+        f"- `summary`: {entry.summary or '(none)'}",
+        f"- `source`: {entry.source.value}",
+        f"- `invocation_mode`: {entry.invocation_mode.value}",
+        f"- `command_alias`: {entry.command or '(none)'}",
+        f"- `command_tool`: {entry.command_tool or '(none)'}",
+        f"- `requires_tools`: {_format_list(entry.requires_tools)}",
+        "- `eligibility`:",
+        f"  - `os`: {_format_list(entry.eligibility.os)}",
+        f"  - `env`: {_format_list(entry.eligibility.env)}",
+        f"  - `binaries`: {_format_list(entry.eligibility.binaries)}",
+    ]
+    return "\n".join(lines)
+
+
+class HelpSkillCommand:
+    """Deterministic `/help <skill>` command handler."""
+
+    def execute(self, call: CommandCall, session: Session) -> CommandResult:
+        """Render snapshot metadata for one skill without executing it."""
+        if len(call.args) != 1:
+            return CommandResult.error("Error: /help requires exactly one skill name.")
+
+        skill_name = call.args[0]
+        target = self._find_skill(session, skill_name)
+        if target is None:
+            return CommandResult.error(
+                f"Error: skill '{skill_name}' not found in snapshot."
+            )
+        return CommandResult.ok(_format_help(target))
+
+    @staticmethod
+    def _find_skill(session: Session, skill_name: str) -> SkillEntry | None:
+        """Look up exact skill name from current session snapshot."""
+        for entry in session.skill_snapshot.skills:
+            if entry.name == skill_name:
+                return entry
+        return None

--- a/src/lily/commands/handlers/reload_skills.py
+++ b/src/lily/commands/handlers/reload_skills.py
@@ -49,9 +49,8 @@ class ReloadSkillsCommand:
         )
         session.skill_snapshot = snapshot
         return CommandResult.ok(
-            (
+            
                 f"Reloaded skills for current session. "
                 f"version={snapshot.version} count={len(snapshot.skills)}"
-            )
+            
         )
-

--- a/src/lily/commands/handlers/reload_skills.py
+++ b/src/lily/commands/handlers/reload_skills.py
@@ -23,13 +23,16 @@ class ReloadSkillsCommand:
         """
         if call.args:
             return CommandResult.error(
-                "Error: /reload_skills does not accept arguments."
+                "Error: /reload_skills does not accept arguments.",
+                code="invalid_args",
+                data={"command": "reload_skills"},
             )
 
         config = session.skill_snapshot_config
         if config is None:
             return CommandResult.error(
-                "Error: /reload_skills is unavailable for this session."
+                "Error: /reload_skills is unavailable for this session.",
+                code="reload_unavailable",
             )
 
         snapshot = build_skill_snapshot(
@@ -49,8 +52,10 @@ class ReloadSkillsCommand:
         )
         session.skill_snapshot = snapshot
         return CommandResult.ok(
-            
+            (
                 f"Reloaded skills for current session. "
                 f"version={snapshot.version} count={len(snapshot.skills)}"
-            
+            ),
+            code="skills_reloaded",
+            data={"version": snapshot.version, "count": len(snapshot.skills)},
         )

--- a/src/lily/commands/handlers/reload_skills.py
+++ b/src/lily/commands/handlers/reload_skills.py
@@ -1,0 +1,57 @@
+"""Handler for /reload_skills."""
+
+from __future__ import annotations
+
+from lily.commands.parser import CommandCall
+from lily.commands.types import CommandResult
+from lily.session.models import Session
+from lily.skills.loader import SkillSnapshotRequest, build_skill_snapshot
+
+
+class ReloadSkillsCommand:
+    """Deterministic `/reload_skills` command handler."""
+
+    def execute(self, call: CommandCall, session: Session) -> CommandResult:
+        """Rebuild and replace the current session skill snapshot.
+
+        Args:
+            call: Parsed command call.
+            session: Session containing current snapshot and reload config.
+
+        Returns:
+            Deterministic success/error result.
+        """
+        if call.args:
+            return CommandResult.error(
+                "Error: /reload_skills does not accept arguments."
+            )
+
+        config = session.skill_snapshot_config
+        if config is None:
+            return CommandResult.error(
+                "Error: /reload_skills is unavailable for this session."
+            )
+
+        snapshot = build_skill_snapshot(
+            SkillSnapshotRequest(
+                bundled_dir=config.bundled_dir,
+                workspace_dir=config.workspace_dir,
+                user_dir=config.user_dir,
+                reserved_commands=set(config.reserved_commands),
+                available_tools=(
+                    set(config.available_tools)
+                    if config.available_tools is not None
+                    else None
+                ),
+                platform=config.platform,
+                env=config.env,
+            )
+        )
+        session.skill_snapshot = snapshot
+        return CommandResult.ok(
+            (
+                f"Reloaded skills for current session. "
+                f"version={snapshot.version} count={len(snapshot.skills)}"
+            )
+        )
+

--- a/src/lily/commands/handlers/skill_invoke.py
+++ b/src/lily/commands/handlers/skill_invoke.py
@@ -47,14 +47,20 @@ class SkillInvokeCommand:
             Command result with explicit success/failure outcome.
         """
         if not call.args:
-            return CommandResult.error("Error: /skill requires a skill name.")
+            return CommandResult.error(
+                "Error: /skill requires a skill name.",
+                code="invalid_args",
+                data={"command": "skill"},
+            )
 
         skill_name = call.args[0]
         user_text = " ".join(call.args[1:])
         target = self._find_skill(session, skill_name)
         if target is None:
             return CommandResult.error(
-                f"Error: skill '{skill_name}' not found in snapshot."
+                f"Error: skill '{skill_name}' not found in snapshot.",
+                code="skill_not_found",
+                data={"skill": skill_name},
             )
 
         return self._invoker.invoke(target, session, user_text)

--- a/src/lily/commands/handlers/skills_list.py
+++ b/src/lily/commands/handlers/skills_list.py
@@ -36,11 +36,23 @@ class SkillsListCommand:
             Command result with deterministic skill list output.
         """
         if call.args:
-            return CommandResult.error("Error: /skills does not accept arguments.")
+            return CommandResult.error(
+                "Error: /skills does not accept arguments.",
+                code="invalid_args",
+                data={"command": "skills"},
+            )
 
         entries = sorted(session.skill_snapshot.skills, key=lambda entry: entry.name)
         if not entries:
-            return CommandResult.ok("No skills available in snapshot.")
+            return CommandResult.ok(
+                "No skills available in snapshot.",
+                code="skills_empty",
+                data={"count": 0},
+            )
 
         lines = [_format_skill_line(entry.name, entry.summary) for entry in entries]
-        return CommandResult.ok("\n".join(lines))
+        return CommandResult.ok(
+            "\n".join(lines),
+            code="skills_listed",
+            data={"count": len(entries)},
+        )

--- a/src/lily/commands/registry.py
+++ b/src/lily/commands/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from lily.commands.handlers.help_skill import HelpSkillCommand
 from lily.commands.handlers.reload_skills import ReloadSkillsCommand
 from lily.commands.handlers.skill_invoke import SkillInvokeCommand
 from lily.commands.handlers.skills_list import SkillsListCommand
@@ -29,6 +30,7 @@ class CommandRegistry:
         self._handlers: dict[str, CommandHandler] = {
             "skills": SkillsListCommand(),
             "skill": SkillInvokeCommand(skill_invoker),
+            "help": HelpSkillCommand(),
             "reload_skills": ReloadSkillsCommand(),
         }
         if handlers:

--- a/src/lily/commands/registry.py
+++ b/src/lily/commands/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from lily.commands.handlers.reload_skills import ReloadSkillsCommand
 from lily.commands.handlers.skill_invoke import SkillInvokeCommand
 from lily.commands.handlers.skills_list import SkillsListCommand
 from lily.commands.parser import CommandCall
@@ -28,6 +29,7 @@ class CommandRegistry:
         self._handlers: dict[str, CommandHandler] = {
             "skills": SkillsListCommand(),
             "skill": SkillInvokeCommand(skill_invoker),
+            "reload_skills": ReloadSkillsCommand(),
         }
         if handlers:
             self._handlers.update(handlers)

--- a/src/lily/commands/registry.py
+++ b/src/lily/commands/registry.py
@@ -55,17 +55,31 @@ class CommandRegistry:
         alias_targets = self._find_alias_targets(session, call.name)
         if len(alias_targets) > 1:
             return CommandResult.error(
-                f"Error: command alias '/{call.name}' is ambiguous in snapshot."
+                f"Error: command alias '/{call.name}' is ambiguous in snapshot.",
+                code="alias_ambiguous",
+                data={"alias": call.name},
             )
         if len(alias_targets) == 1:
             user_text = " ".join(call.args)
             return self._skill_invoker.invoke(alias_targets[0], session, user_text)
 
-        return CommandResult.error(f"Error: unknown command '/{call.name}'.")
+        return CommandResult.error(
+            f"Error: unknown command '/{call.name}'.",
+            code="unknown_command",
+            data={"command": call.name},
+        )
 
     @staticmethod
     def _find_alias_targets(session: Session, alias_name: str) -> list[SkillEntry]:
-        """Return skills in snapshot that expose matching command alias."""
+        """Return skills in snapshot that expose matching command alias.
+
+        Args:
+            session: Active session whose snapshot should be queried.
+            alias_name: Alias name from parsed slash command.
+
+        Returns:
+            Matching skill entries with same alias.
+        """
         return [
             entry
             for entry in session.skill_snapshot.skills

--- a/src/lily/commands/types.py
+++ b/src/lily/commands/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Protocol
+from typing import Any, Protocol
 
 from pydantic import BaseModel, ConfigDict
 
@@ -24,31 +24,49 @@ class CommandResult(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     status: CommandStatus
+    code: str
     message: str
+    data: dict[str, Any] | None = None
 
     @classmethod
-    def ok(cls, message: str) -> CommandResult:
+    def ok(
+        cls,
+        message: str,
+        *,
+        code: str = "ok",
+        data: dict[str, Any] | None = None,
+    ) -> CommandResult:
         """Construct a successful command result.
 
         Args:
             message: User-facing output payload.
+            code: Stable machine-readable success code.
+            data: Optional structured payload for downstream consumers.
 
         Returns:
             Successful command result.
         """
-        return cls(status=CommandStatus.OK, message=message)
+        return cls(status=CommandStatus.OK, code=code, message=message, data=data)
 
     @classmethod
-    def error(cls, message: str) -> CommandResult:
+    def error(
+        cls,
+        message: str,
+        *,
+        code: str = "error",
+        data: dict[str, Any] | None = None,
+    ) -> CommandResult:
         """Construct an error command result.
 
         Args:
             message: User-facing error payload.
+            code: Stable machine-readable error code.
+            data: Optional structured payload for downstream consumers.
 
         Returns:
             Error command result.
         """
-        return cls(status=CommandStatus.ERROR, message=message)
+        return cls(status=CommandStatus.ERROR, code=code, message=message, data=data)
 
 
 class CommandHandler(Protocol):

--- a/src/lily/runtime/executors/llm_orchestration.py
+++ b/src/lily/runtime/executors/llm_orchestration.py
@@ -49,9 +49,17 @@ class LlmOrchestrationExecutor:
         )
         try:
             response = self._backend.run(request)
-            return CommandResult.ok(response.text)
+            return CommandResult.ok(
+                response.text,
+                code="llm_ok",
+                data={"skill": entry.name},
+            )
         except LlmBackendError as exc:
-            return CommandResult.error(self._map_backend_error(exc.code))
+            return CommandResult.error(
+                self._map_backend_error(exc.code),
+                code=f"llm_{exc.code.value}",
+                data={"skill": entry.name, "backend_code": exc.code.value},
+            )
 
     @staticmethod
     def _map_backend_error(code: LlmBackendErrorCode) -> str:

--- a/src/lily/runtime/executors/llm_orchestration.py
+++ b/src/lily/runtime/executors/llm_orchestration.py
@@ -43,6 +43,7 @@ class LlmOrchestrationExecutor:
             session_id=session.session_id,
             skill_name=entry.name,
             skill_summary=entry.summary,
+            skill_instructions=entry.instructions,
             user_text=user_text,
             model_name=session.model_settings.model_name,
         )

--- a/src/lily/runtime/executors/tool_dispatch.py
+++ b/src/lily/runtime/executors/tool_dispatch.py
@@ -18,7 +18,13 @@ class ToolDispatchTool(Protocol):
     def execute(
         self, payload: str, *, session: Session, skill_name: str
     ) -> CommandResult:
-        """Execute tool with raw payload."""
+        """Execute tool with raw payload.
+
+        Args:
+            payload: Raw user payload.
+            session: Active session context.
+            skill_name: Calling skill name.
+        """
 
 
 class AddTool:
@@ -30,19 +36,32 @@ class AddTool:
     def execute(
         self, payload: str, *, session: Session, skill_name: str
     ) -> CommandResult:
-        """Evaluate `<number>+<number>` and return deterministic result."""
+        """Evaluate `<number>+<number>` and return deterministic result.
+
+        Args:
+            payload: Raw user expression payload.
+            session: Active session context.
+            skill_name: Calling skill name.
+
+        Returns:
+            Deterministic add-tool result.
+        """
         del session
         del skill_name
         text = payload.strip()
         if not text:
             return CommandResult.error(
-                "Error: add tool requires an expression like '2+2'."
+                "Error: add tool requires an expression like '2+2'.",
+                code="tool_invalid_args",
+                data={"tool": self.name},
             )
 
         match = self._EXPR_RE.fullmatch(text)
         if match is None:
             return CommandResult.error(
-                "Error: add tool expects format '<number>+<number>'."
+                "Error: add tool expects format '<number>+<number>'.",
+                code="tool_invalid_args",
+                data={"tool": self.name},
             )
 
         left = float(match.group(1))
@@ -50,8 +69,16 @@ class AddTool:
         total = left + right
 
         if total.is_integer():
-            return CommandResult.ok(str(int(total)))
-        return CommandResult.ok(str(total))
+            return CommandResult.ok(
+                str(int(total)),
+                code="tool_ok",
+                data={"tool": self.name},
+            )
+        return CommandResult.ok(
+            str(total),
+            code="tool_ok",
+            data={"tool": self.name},
+        )
 
 
 class ToolDispatchExecutor:
@@ -60,7 +87,11 @@ class ToolDispatchExecutor:
     mode = InvocationMode.TOOL_DISPATCH
 
     def __init__(self, tools: tuple[ToolDispatchTool, ...]) -> None:
-        """Build deterministic tool registry keyed by tool name."""
+        """Build deterministic tool registry keyed by tool name.
+
+        Args:
+            tools: Registered dispatch tools.
+        """
         self._tools = {tool.name: tool for tool in tools}
 
     def execute(
@@ -78,13 +109,23 @@ class ToolDispatchExecutor:
         """
         if not entry.command_tool:
             return CommandResult.error(
-                f"Error: skill '{entry.name}' is missing command_tool for tool_dispatch."
+                (
+                    f"Error: skill '{entry.name}' is missing command_tool "
+                    "for tool_dispatch."
+                ),
+                code="command_tool_missing",
+                data={"skill": entry.name},
             )
 
         tool = self._tools.get(entry.command_tool)
         if tool is None:
             return CommandResult.error(
-                f"Error: command tool '{entry.command_tool}' is not registered for skill '{entry.name}'."
+                (
+                    f"Error: command tool '{entry.command_tool}' is not registered "
+                    f"for skill '{entry.name}'."
+                ),
+                code="command_tool_unregistered",
+                data={"skill": entry.name, "tool": entry.command_tool},
             )
 
         return tool.execute(user_text, session=session, skill_name=entry.name)

--- a/src/lily/runtime/executors/tool_dispatch.py
+++ b/src/lily/runtime/executors/tool_dispatch.py
@@ -1,21 +1,68 @@
-"""Tool-dispatch skill executor placeholder."""
+"""Tool-dispatch skill executor."""
 
 from __future__ import annotations
+
+import re
+from typing import Protocol
 
 from lily.commands.types import CommandResult
 from lily.session.models import Session
 from lily.skills.types import InvocationMode, SkillEntry
 
 
+class ToolDispatchTool(Protocol):
+    """Protocol for deterministic command-tool implementations."""
+
+    name: str
+
+    def execute(self, payload: str, *, session: Session, skill_name: str) -> CommandResult:
+        """Execute tool with raw payload."""
+
+
+class AddTool:
+    """Deterministic add tool for simple arithmetic expressions."""
+
+    name = "add"
+    _EXPR_RE = re.compile(
+        r"^\s*(-?\d+(?:\.\d+)?)\s*\+\s*(-?\d+(?:\.\d+)?)\s*$"
+    )
+
+    def execute(self, payload: str, *, session: Session, skill_name: str) -> CommandResult:
+        """Evaluate `<number>+<number>` and return deterministic result."""
+        del session
+        del skill_name
+        text = payload.strip()
+        if not text:
+            return CommandResult.error("Error: add tool requires an expression like '2+2'.")
+
+        match = self._EXPR_RE.fullmatch(text)
+        if match is None:
+            return CommandResult.error(
+                "Error: add tool expects format '<number>+<number>'."
+            )
+
+        left = float(match.group(1))
+        right = float(match.group(2))
+        total = left + right
+
+        if total.is_integer():
+            return CommandResult.ok(str(int(total)))
+        return CommandResult.ok(str(total))
+
+
 class ToolDispatchExecutor:
-    """Placeholder executor for `tool_dispatch` invocation mode."""
+    """Execute `tool_dispatch` skills by direct tool invocation."""
 
     mode = InvocationMode.TOOL_DISPATCH
+
+    def __init__(self, tools: tuple[ToolDispatchTool, ...]) -> None:
+        """Build deterministic tool registry keyed by tool name."""
+        self._tools = {tool.name: tool for tool in tools}
 
     def execute(
         self, entry: SkillEntry, session: Session, user_text: str
     ) -> CommandResult:
-        """Return explicit deferred message for `tool_dispatch`.
+        """Dispatch to configured command tool for entry.
 
         Args:
             entry: Skill entry selected from snapshot.
@@ -23,10 +70,17 @@ class ToolDispatchExecutor:
             user_text: User payload for skill execution.
 
         Returns:
-            Explicit not-yet-implemented command result.
+            Deterministic command-tool execution result.
         """
-        del session
-        del user_text
-        return CommandResult.error(
-            f"Error: tool_dispatch executor is not implemented for '{entry.name}'."
-        )
+        if not entry.command_tool:
+            return CommandResult.error(
+                f"Error: skill '{entry.name}' is missing command_tool for tool_dispatch."
+            )
+
+        tool = self._tools.get(entry.command_tool)
+        if tool is None:
+            return CommandResult.error(
+                f"Error: command tool '{entry.command_tool}' is not registered for skill '{entry.name}'."
+            )
+
+        return tool.execute(user_text, session=session, skill_name=entry.name)

--- a/src/lily/runtime/executors/tool_dispatch.py
+++ b/src/lily/runtime/executors/tool_dispatch.py
@@ -15,7 +15,9 @@ class ToolDispatchTool(Protocol):
 
     name: str
 
-    def execute(self, payload: str, *, session: Session, skill_name: str) -> CommandResult:
+    def execute(
+        self, payload: str, *, session: Session, skill_name: str
+    ) -> CommandResult:
         """Execute tool with raw payload."""
 
 
@@ -23,17 +25,19 @@ class AddTool:
     """Deterministic add tool for simple arithmetic expressions."""
 
     name = "add"
-    _EXPR_RE = re.compile(
-        r"^\s*(-?\d+(?:\.\d+)?)\s*\+\s*(-?\d+(?:\.\d+)?)\s*$"
-    )
+    _EXPR_RE = re.compile(r"^\s*(-?\d+(?:\.\d+)?)\s*\+\s*(-?\d+(?:\.\d+)?)\s*$")
 
-    def execute(self, payload: str, *, session: Session, skill_name: str) -> CommandResult:
+    def execute(
+        self, payload: str, *, session: Session, skill_name: str
+    ) -> CommandResult:
         """Evaluate `<number>+<number>` and return deterministic result."""
         del session
         del skill_name
         text = payload.strip()
         if not text:
-            return CommandResult.error("Error: add tool requires an expression like '2+2'.")
+            return CommandResult.error(
+                "Error: add tool requires an expression like '2+2'."
+            )
 
         match = self._EXPR_RE.fullmatch(text)
         if match is None:

--- a/src/lily/runtime/facade.py
+++ b/src/lily/runtime/facade.py
@@ -6,7 +6,7 @@ from lily.commands.parser import CommandParseError, ParsedInputKind, parse_input
 from lily.commands.registry import CommandRegistry
 from lily.commands.types import CommandResult
 from lily.runtime.executors.llm_orchestration import LlmOrchestrationExecutor
-from lily.runtime.executors.tool_dispatch import ToolDispatchExecutor
+from lily.runtime.executors.tool_dispatch import AddTool, ToolDispatchExecutor
 from lily.runtime.llm_backend import LangChainBackend
 from lily.runtime.skill_invoker import SkillInvoker
 from lily.session.models import Session
@@ -55,7 +55,7 @@ class RuntimeFacade:
         llm_backend = LangChainBackend()
         executors = (
             LlmOrchestrationExecutor(llm_backend),
-            ToolDispatchExecutor(),
+            ToolDispatchExecutor(tools=(AddTool(),)),
         )
         invoker = SkillInvoker(executors=executors)
         return CommandRegistry(skill_invoker=invoker)

--- a/src/lily/runtime/facade.py
+++ b/src/lily/runtime/facade.py
@@ -6,10 +6,11 @@ from lily.commands.parser import CommandParseError, ParsedInputKind, parse_input
 from lily.commands.registry import CommandRegistry
 from lily.commands.types import CommandResult
 from lily.runtime.executors.llm_orchestration import LlmOrchestrationExecutor
+from lily.runtime.session_lanes import run_in_session_lane
 from lily.runtime.executors.tool_dispatch import AddTool, ToolDispatchExecutor
 from lily.runtime.llm_backend import LangChainBackend
 from lily.runtime.skill_invoker import SkillInvoker
-from lily.session.models import Session
+from lily.session.models import Message, MessageRole, Session
 
 
 class RuntimeFacade:
@@ -33,17 +34,28 @@ class RuntimeFacade:
         Returns:
             Deterministic result for command/conversation routing.
         """
+        return run_in_session_lane(
+            session.session_id,
+            lambda: self._handle_input_serialized(text=text, session=session),
+        )
+
+    def _handle_input_serialized(self, *, text: str, session: Session) -> CommandResult:
+        """Handle one input while holding per-session execution lane."""
         try:
             parsed = parse_input(text)
         except CommandParseError as exc:
             return CommandResult.error(str(exc))
 
         if parsed.kind == ParsedInputKind.COMMAND and parsed.command is not None:
-            return self._command_registry.dispatch(parsed.command, session)
+            result = self._command_registry.dispatch(parsed.command, session)
+            self._record_turn(session, user_text=text, assistant_text=result.message)
+            return result
 
-        return CommandResult.error(
+        result = CommandResult.error(
             "Error: non-command conversational routing is not implemented yet."
         )
+        self._record_turn(session, user_text=text, assistant_text=result.message)
+        return result
 
     @staticmethod
     def _build_default_registry() -> CommandRegistry:
@@ -59,3 +71,13 @@ class RuntimeFacade:
         )
         invoker = SkillInvoker(executors=executors)
         return CommandRegistry(skill_invoker=invoker)
+
+    @staticmethod
+    def _record_turn(session: Session, *, user_text: str, assistant_text: str) -> None:
+        """Append deterministic user/assistant events to conversation state."""
+        session.conversation_state.append(
+            Message(role=MessageRole.USER, content=user_text)
+        )
+        session.conversation_state.append(
+            Message(role=MessageRole.ASSISTANT, content=assistant_text)
+        )

--- a/src/lily/runtime/llm_backend/base.py
+++ b/src/lily/runtime/llm_backend/base.py
@@ -16,6 +16,7 @@ class LlmRunRequest(BaseModel):
     session_id: str = Field(min_length=1)
     skill_name: str = Field(min_length=1)
     skill_summary: str
+    skill_instructions: str = ""
     user_text: str
     model_name: str = Field(min_length=1)
 

--- a/src/lily/runtime/llm_backend/langchain_adapter.py
+++ b/src/lily/runtime/llm_backend/langchain_adapter.py
@@ -69,16 +69,12 @@ class _LangChainV1Invoker:
             "You are Lily executing a specific skill.\n"
             f"Skill name: {request.skill_name}\n"
             f"Skill summary: {request.skill_summary or 'No summary provided.'}\n"
-            "Follow the skill intent precisely and respond directly."
+            "Follow the skill intent precisely and respond directly.\n"
         )
-        if request.skill_name == "echo":
-            return (
-                f"{base}\n"
-                "For this skill, return exactly the user payload transformed to "
-                "uppercase. "
-                "Return only the uppercase text."
-            )
-        return base
+        instructions = request.skill_instructions.strip()
+        if not instructions:
+            return base
+        return f"{base}Skill instructions:\n{instructions}"
 
     @staticmethod
     def _extract_text(result: object) -> str:
@@ -240,6 +236,7 @@ class LangChainBackend:
             session_id=request.session_id,
             skill_name=request.skill_name,
             skill_summary=request.skill_summary.strip(),
+            skill_instructions=request.skill_instructions.strip(),
             user_text=request.user_text.strip(),
             model_name=request.model_name,
         )

--- a/src/lily/runtime/session_lanes.py
+++ b/src/lily/runtime/session_lanes.py
@@ -1,0 +1,28 @@
+"""Per-session execution lane primitives."""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import Callable, TypeVar
+
+_T = TypeVar("_T")
+
+_registry_lock = Lock()
+_session_lanes: dict[str, Lock] = {}
+
+
+def run_in_session_lane(session_id: str, fn: Callable[[], _T]) -> _T:
+    """Execute function while holding per-session lane lock."""
+    with _registry_lock:
+        lane = _session_lanes.get(session_id)
+        if lane is None:
+            lane = Lock()
+            _session_lanes[session_id] = lane
+    with lane:
+        return fn()
+
+
+def reset_session_lanes() -> None:
+    """Reset all lane locks (test-only helper)."""
+    with _registry_lock:
+        _session_lanes.clear()

--- a/src/lily/runtime/session_lanes.py
+++ b/src/lily/runtime/session_lanes.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from threading import Lock
-from typing import Callable, TypeVar
-
-_T = TypeVar("_T")
 
 _registry_lock = Lock()
 _session_lanes: dict[str, Lock] = {}
 
 
-def run_in_session_lane(session_id: str, fn: Callable[[], _T]) -> _T:
-    """Execute function while holding per-session lane lock."""
+def run_in_session_lane[T](session_id: str, fn: Callable[[], T]) -> T:
+    """Execute function while holding per-session lane lock.
+
+    Args:
+        session_id: Session identifier used to resolve lane lock.
+        fn: Function to execute under lane lock.
+
+    Returns:
+        Function return value.
+    """
     with _registry_lock:
         lane = _session_lanes.get(session_id)
         if lane is None:

--- a/src/lily/runtime/skill_invoker.py
+++ b/src/lily/runtime/skill_invoker.py
@@ -49,5 +49,7 @@ class SkillInvoker:
             Error result.
         """
         return CommandResult.error(
-            f"Error: no executor bound for mode '{mode.value}' (skill '{skill_name}')."
+            f"Error: no executor bound for mode '{mode.value}' (skill '{skill_name}').",
+            code="executor_unbound",
+            data={"mode": mode.value, "skill": skill_name},
         )

--- a/src/lily/session/factory.py
+++ b/src/lily/session/factory.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from lily.session.models import ModelConfig, Session
+from lily.session.models import ModelConfig, Session, SkillSnapshotConfig
 from lily.skills.loader import SkillSnapshotRequest, build_skill_snapshot
 
 
@@ -68,6 +68,19 @@ class SessionFactory:
             "active_agent": active_agent,
             "skill_snapshot": snapshot,
             "model_config": model_config or ModelConfig(),
+            "skill_snapshot_config": SkillSnapshotConfig(
+                bundled_dir=self._config.bundled_dir,
+                workspace_dir=self._config.workspace_dir,
+                user_dir=self._config.user_dir,
+                reserved_commands=tuple(sorted(self._config.reserved_commands)),
+                available_tools=(
+                    tuple(sorted(self._config.available_tools))
+                    if self._config.available_tools is not None
+                    else None
+                ),
+                platform=self._config.platform,
+                env=self._config.env,
+            ),
         }
         if session_id is not None:
             payload["session_id"] = session_id

--- a/src/lily/session/models.py
+++ b/src/lily/session/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from pathlib import Path
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -49,3 +50,18 @@ class Session(BaseModel):
     skill_snapshot: SkillSnapshot
     model_settings: ModelConfig = Field(alias="model_config")
     conversation_state: list[Message] = Field(default_factory=list)
+    skill_snapshot_config: "SkillSnapshotConfig | None" = None
+
+
+class SkillSnapshotConfig(BaseModel):
+    """Session-scoped config used to rebuild skill snapshots deterministically."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    bundled_dir: Path
+    workspace_dir: Path
+    user_dir: Path | None = None
+    reserved_commands: tuple[str, ...] = ()
+    available_tools: tuple[str, ...] | None = None
+    platform: str | None = None
+    env: dict[str, str] | None = None

--- a/src/lily/session/models.py
+++ b/src/lily/session/models.py
@@ -50,7 +50,7 @@ class Session(BaseModel):
     skill_snapshot: SkillSnapshot
     model_settings: ModelConfig = Field(alias="model_config")
     conversation_state: list[Message] = Field(default_factory=list)
-    skill_snapshot_config: "SkillSnapshotConfig | None" = None
+    skill_snapshot_config: SkillSnapshotConfig | None = None
 
 
 class SkillSnapshotConfig(BaseModel):

--- a/src/lily/session/store.py
+++ b/src/lily/session/store.py
@@ -1,0 +1,90 @@
+"""Session persistence and reload helpers."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from lily.session.models import Session
+
+SESSION_SCHEMA_VERSION = 1
+
+
+class SessionStoreError(RuntimeError):
+    """Base persistence error for session store operations."""
+
+
+class SessionSchemaVersionError(SessionStoreError):
+    """Raised when persisted payload schema version is unsupported."""
+
+
+class SessionDecodeError(SessionStoreError):
+    """Raised when persisted payload cannot be decoded/validated."""
+
+
+class PersistedSessionV1(BaseModel):
+    """Versioned persisted session payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = SESSION_SCHEMA_VERSION
+    session: Session
+
+
+def save_session(session: Session, path: Path) -> None:
+    """Persist full session payload atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = PersistedSessionV1(session=session)
+    temp_path = path.with_name(f"{path.name}.tmp")
+    temp_path.write_text(
+        payload.model_dump_json(indent=2, by_alias=True),
+        encoding="utf-8",
+    )
+    temp_path.replace(path)
+
+
+def load_session(path: Path) -> Session:
+    """Load persisted session payload from disk."""
+    raw = path.read_text(encoding="utf-8")
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SessionDecodeError(f"Invalid session JSON: {exc}") from exc
+
+    migrated = _migrate_payload(decoded)
+    try:
+        payload = PersistedSessionV1.model_validate(migrated)
+    except ValidationError as exc:
+        raise SessionDecodeError(f"Invalid session payload: {exc}") from exc
+    return payload.session
+
+
+def recover_corrupt_session(path: Path) -> Path | None:
+    """Move unreadable/invalid session aside and return backup path."""
+    if not path.exists():
+        return None
+    timestamp = int(time.time())
+    backup = path.with_name(f"{path.name}.corrupt-{timestamp}")
+    path.replace(backup)
+    return backup
+
+
+def _migrate_payload(payload: Any) -> dict[str, Any]:
+    """Migrate persisted payload into latest schema.
+
+    Migration stubs for future versions belong here.
+    """
+    if not isinstance(payload, dict):
+        raise SessionDecodeError("Invalid session payload: expected JSON object.")
+    version = payload.get("schema_version")
+    if version == SESSION_SCHEMA_VERSION:
+        return payload
+    raise SessionSchemaVersionError(
+        f"Unsupported session schema version: {version!r}. "
+        f"Expected {SESSION_SCHEMA_VERSION}."
+    )
+

--- a/src/lily/skills/loader.py
+++ b/src/lily/skills/loader.py
@@ -140,6 +140,7 @@ def _hash_snapshot(
                 "source": entry.source.value,
                 "path": entry.path.as_posix(),
                 "summary": entry.summary,
+                "instructions": entry.instructions,
                 "invocation_mode": entry.invocation_mode.value,
                 "command": entry.command,
                 "command_tool": entry.command_tool,
@@ -258,7 +259,7 @@ def _resolve_candidate(
     Returns:
         A tuple of optional resolved entry and diagnostics for this candidate.
     """
-    metadata, _body, parse_error = _read_skill_metadata(candidate.path)
+    metadata, body, parse_error = _read_skill_metadata(candidate.path)
     if parse_error:
         return None, (
             SkillDiagnostic(
@@ -293,6 +294,7 @@ def _resolve_candidate(
         source=candidate.source,
         path=(candidate.path / SKILL_FILENAME).resolve(),
         summary=metadata.summary,
+        instructions=body.strip(),
         invocation_mode=metadata.invocation_mode,
         command=metadata.command,
         command_tool=metadata.command_tool,

--- a/src/lily/skills/types.py
+++ b/src/lily/skills/types.py
@@ -77,6 +77,7 @@ class SkillEntry(BaseModel):
     source: SkillSource
     path: Path
     summary: str = ""
+    instructions: str = ""
     invocation_mode: InvocationMode = InvocationMode.LLM_ORCHESTRATION
     command: str | None = None
     command_tool: str | None = None

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from _pytest.monkeypatch import MonkeyPatch
@@ -146,3 +147,125 @@ def test_repl_exit_parentheses_exits_cleanly(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert "bye" in result.stdout
+
+
+def test_run_persists_session_and_requires_reload_for_new_skills(tmp_path: Path) -> None:
+    """Run mode should persist snapshot and keep it stable until /reload_skills."""
+    bundled_dir = tmp_path / "bundled"
+    workspace_dir = tmp_path / "workspace"
+    session_file = tmp_path / "session.json"
+    bundled_dir.mkdir()
+    workspace_dir.mkdir()
+    _write_echo_skill(bundled_dir)
+
+    first = _RUNNER.invoke(
+        app,
+        [
+            "run",
+            "/skills",
+            "--bundled-dir",
+            str(bundled_dir),
+            "--workspace-dir",
+            str(workspace_dir),
+            "--session-file",
+            str(session_file),
+        ],
+    )
+    assert first.exit_code == 0
+    assert "echo - Echo" in first.stdout
+    assert session_file.exists()
+
+    demo_dir = workspace_dir / "demo"
+    demo_dir.mkdir()
+    (demo_dir / "SKILL.md").write_text(
+        (
+            "---\n"
+            "summary: Demo\n"
+            "invocation_mode: llm_orchestration\n"
+            "---\n"
+            "# Demo\n"
+        ),
+        encoding="utf-8",
+    )
+
+    second = _RUNNER.invoke(
+        app,
+        [
+            "run",
+            "/skills",
+            "--bundled-dir",
+            str(bundled_dir),
+            "--workspace-dir",
+            str(workspace_dir),
+            "--session-file",
+            str(session_file),
+        ],
+    )
+    assert second.exit_code == 0
+    assert "echo - Echo" in second.stdout
+    assert "demo - Demo" not in second.stdout
+
+    reload_result = _RUNNER.invoke(
+        app,
+        [
+            "run",
+            "/reload_skills",
+            "--bundled-dir",
+            str(bundled_dir),
+            "--workspace-dir",
+            str(workspace_dir),
+            "--session-file",
+            str(session_file),
+        ],
+    )
+    assert reload_result.exit_code == 0
+    assert "Reloaded skills for current session." in reload_result.stdout
+
+    third = _RUNNER.invoke(
+        app,
+        [
+            "run",
+            "/skills",
+            "--bundled-dir",
+            str(bundled_dir),
+            "--workspace-dir",
+            str(workspace_dir),
+            "--session-file",
+            str(session_file),
+        ],
+    )
+    assert third.exit_code == 0
+    assert "demo - Demo" in third.stdout
+
+
+def test_repl_recovers_corrupt_session_file(tmp_path: Path) -> None:
+    """REPL should recover by moving corrupt session aside and creating new session."""
+    bundled_dir = tmp_path / "bundled"
+    workspace_dir = tmp_path / "workspace"
+    session_file = tmp_path / "session.json"
+    bundled_dir.mkdir()
+    workspace_dir.mkdir()
+    _write_echo_skill(bundled_dir)
+
+    session_file.write_text("{not json", encoding="utf-8")
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "repl",
+            "--bundled-dir",
+            str(bundled_dir),
+            "--workspace-dir",
+            str(workspace_dir),
+            "--session-file",
+            str(session_file),
+        ],
+        input="exit\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Session file was invalid." in result.stdout
+    backups = list(tmp_path.glob("session.json.corrupt-*"))
+    assert backups
+    payload = json.loads(session_file.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -149,7 +149,9 @@ def test_repl_exit_parentheses_exits_cleanly(tmp_path: Path) -> None:
     assert "bye" in result.stdout
 
 
-def test_run_persists_session_and_requires_reload_for_new_skills(tmp_path: Path) -> None:
+def test_run_persists_session_and_requires_reload_for_new_skills(
+    tmp_path: Path,
+) -> None:
     """Run mode should persist snapshot and keep it stable until /reload_skills."""
     bundled_dir = tmp_path / "bundled"
     workspace_dir = tmp_path / "workspace"
@@ -178,13 +180,7 @@ def test_run_persists_session_and_requires_reload_for_new_skills(tmp_path: Path)
     demo_dir = workspace_dir / "demo"
     demo_dir.mkdir()
     (demo_dir / "SKILL.md").write_text(
-        (
-            "---\n"
-            "summary: Demo\n"
-            "invocation_mode: llm_orchestration\n"
-            "---\n"
-            "# Demo\n"
-        ),
+        ("---\nsummary: Demo\ninvocation_mode: llm_orchestration\n---\n# Demo\n"),
         encoding="utf-8",
     )
 

--- a/tests/unit/commands/test_command_surface.py
+++ b/tests/unit/commands/test_command_surface.py
@@ -41,6 +41,9 @@ def _make_skill(
     Args:
         name: Skill name.
         summary: Skill summary text.
+        mode: Invocation mode for the skill fixture.
+        command_tool: Optional tool name for tool_dispatch fixtures.
+        command: Optional alias command exposed by the skill.
 
     Returns:
         Skill entry fixture.
@@ -278,7 +281,12 @@ def test_alias_collision_returns_deterministic_error() -> None:
     runtime = RuntimeFacade()
     session = _make_session(
         skills=(
-            _make_skill("add", mode=InvocationMode.TOOL_DISPATCH, command_tool="add", command="go"),
+            _make_skill(
+                "add",
+                mode=InvocationMode.TOOL_DISPATCH,
+                command_tool="add",
+                command="go",
+            ),
             _make_skill("echo", command="go"),
         )
     )

--- a/tests/unit/commands/test_command_surface.py
+++ b/tests/unit/commands/test_command_surface.py
@@ -306,3 +306,17 @@ def test_built_in_command_precedence_over_alias() -> None:
         "alpha - Alpha summary",
         "echo",
     ]
+
+
+def test_runtime_records_turns_in_conversation_state() -> None:
+    """Runtime should append user/assistant entries to session conversation state."""
+    runtime = RuntimeFacade()
+    session = _make_session(skills=())
+
+    result = runtime.handle_input("/skills", session)
+
+    assert result.status.value == "ok"
+    assert len(session.conversation_state) == 2
+    assert session.conversation_state[0].role.value == "user"
+    assert session.conversation_state[0].content == "/skills"
+    assert session.conversation_state[1].role.value == "assistant"

--- a/tests/unit/runtime/test_langchain_backend.py
+++ b/tests/unit/runtime/test_langchain_backend.py
@@ -8,6 +8,7 @@ from lily.runtime.llm_backend import (
     LangChainBackend,
     LlmRunRequest,
 )
+from lily.runtime.llm_backend.langchain_adapter import _LangChainV1Invoker
 
 
 class _SuccessInvoker:
@@ -115,3 +116,20 @@ def test_langchain_backend_fails_fast_on_invalid_response() -> None:
         assert "empty output" in str(exc)
     else:  # pragma: no cover - safety assertion
         raise AssertionError("Expected BackendInvalidResponseError")
+
+
+def test_system_prompt_uses_skill_instructions_without_skill_name_hardcoding() -> None:
+    """Prompt construction should use instructions generically with no echo branch."""
+    request = LlmRunRequest(
+        session_id="session-test",
+        skill_name="echo",
+        skill_summary="Echo skill",
+        skill_instructions="Return the text in lowercase.",
+        user_text="HELLO",
+        model_name="default",
+    )
+
+    prompt = _LangChainV1Invoker._build_system_prompt(request)
+
+    assert "Skill instructions:\nReturn the text in lowercase." in prompt
+    assert "user payload transformed to uppercase" not in prompt

--- a/tests/unit/runtime/test_session_lanes.py
+++ b/tests/unit/runtime/test_session_lanes.py
@@ -26,8 +26,7 @@ class _TrackingRegistry:
         del session
         with self.lock:
             self.active += 1
-            if self.active > self.max_active:
-                self.max_active = self.active
+            self.max_active = max(self.max_active, self.active)
         try:
             time.sleep(0.05)
             return CommandResult.ok("ok")

--- a/tests/unit/runtime/test_session_lanes.py
+++ b/tests/unit/runtime/test_session_lanes.py
@@ -1,0 +1,91 @@
+"""Unit tests for per-session execution lane behavior."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+
+from lily.commands.types import CommandResult
+from lily.runtime.facade import RuntimeFacade
+from lily.runtime.session_lanes import reset_session_lanes
+from lily.session.models import ModelConfig, Session
+from lily.skills.types import SkillSnapshot
+
+
+@dataclass
+class _TrackingRegistry:
+    """Test registry tracking concurrent dispatch execution."""
+
+    active: int = 0
+    max_active: int = 0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def dispatch(self, call: object, session: Session) -> CommandResult:
+        del call
+        del session
+        with self.lock:
+            self.active += 1
+            if self.active > self.max_active:
+                self.max_active = self.active
+        try:
+            time.sleep(0.05)
+            return CommandResult.ok("ok")
+        finally:
+            with self.lock:
+                self.active -= 1
+
+
+def _session(session_id: str) -> Session:
+    """Create minimal session fixture."""
+    return Session(
+        session_id=session_id,
+        active_agent="default",
+        skill_snapshot=SkillSnapshot(version="v-test", skills=()),
+        model_config=ModelConfig(),
+    )
+
+
+def test_runtime_serializes_same_session_inputs() -> None:
+    """Same session should execute one dispatch at a time."""
+    reset_session_lanes()
+    registry = _TrackingRegistry()
+    runtime = RuntimeFacade(command_registry=registry)  # type: ignore[arg-type]
+    session = _session("session-a")
+
+    start = threading.Barrier(2)
+    t1 = threading.Thread(
+        target=lambda: (start.wait(), runtime.handle_input("/skills", session))
+    )
+    t2 = threading.Thread(
+        target=lambda: (start.wait(), runtime.handle_input("/skills", session))
+    )
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert registry.max_active == 1
+
+
+def test_runtime_allows_parallel_inputs_across_sessions() -> None:
+    """Different sessions should be able to run in parallel lanes."""
+    reset_session_lanes()
+    registry = _TrackingRegistry()
+    runtime = RuntimeFacade(command_registry=registry)  # type: ignore[arg-type]
+    session_a = _session("session-a")
+    session_b = _session("session-b")
+
+    start = threading.Barrier(2)
+    t1 = threading.Thread(
+        target=lambda: (start.wait(), runtime.handle_input("/skills", session_a))
+    )
+    t2 = threading.Thread(
+        target=lambda: (start.wait(), runtime.handle_input("/skills", session_b))
+    )
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert registry.max_active >= 2

--- a/tests/unit/runtime/test_tool_dispatch_executor.py
+++ b/tests/unit/runtime/test_tool_dispatch_executor.py
@@ -68,4 +68,3 @@ def test_tool_dispatch_fails_for_unknown_tool() -> None:
         result.message
         == "Error: command tool 'missing_tool' is not registered for skill 'add'."
     )
-

--- a/tests/unit/runtime/test_tool_dispatch_executor.py
+++ b/tests/unit/runtime/test_tool_dispatch_executor.py
@@ -1,0 +1,71 @@
+"""Unit tests for tool-dispatch executor behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lily.runtime.executors.tool_dispatch import AddTool, ToolDispatchExecutor
+from lily.session.models import ModelConfig, Session
+from lily.skills.types import InvocationMode, SkillEntry, SkillSnapshot, SkillSource
+
+
+def _session() -> Session:
+    """Create minimal session fixture for executor tests."""
+    return Session(
+        session_id="session-dispatch-test",
+        active_agent="default",
+        skill_snapshot=SkillSnapshot(version="v-test", skills=()),
+        model_config=ModelConfig(),
+    )
+
+
+def _entry(
+    *,
+    name: str = "add",
+    command_tool: str | None = "add",
+) -> SkillEntry:
+    """Create tool_dispatch skill entry fixture."""
+    return SkillEntry(
+        name=name,
+        source=SkillSource.BUNDLED,
+        path=Path(f"/skills/{name}/SKILL.md"),
+        invocation_mode=InvocationMode.TOOL_DISPATCH,
+        command_tool=command_tool,
+    )
+
+
+def test_tool_dispatch_executes_registered_tool() -> None:
+    """Registered command tool should execute and return deterministic result."""
+    executor = ToolDispatchExecutor(tools=(AddTool(),))
+
+    result = executor.execute(_entry(), _session(), "2+2")
+
+    assert result.status.value == "ok"
+    assert result.message == "4"
+
+
+def test_tool_dispatch_requires_command_tool() -> None:
+    """Executor should fail clearly when entry lacks command_tool."""
+    executor = ToolDispatchExecutor(tools=(AddTool(),))
+
+    result = executor.execute(_entry(command_tool=None), _session(), "2+2")
+
+    assert result.status.value == "error"
+    assert (
+        result.message
+        == "Error: skill 'add' is missing command_tool for tool_dispatch."
+    )
+
+
+def test_tool_dispatch_fails_for_unknown_tool() -> None:
+    """Executor should fail clearly for unregistered tool names."""
+    executor = ToolDispatchExecutor(tools=(AddTool(),))
+
+    result = executor.execute(_entry(command_tool="missing_tool"), _session(), "2+2")
+
+    assert result.status.value == "error"
+    assert (
+        result.message
+        == "Error: command tool 'missing_tool' is not registered for skill 'add'."
+    )
+

--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -67,4 +67,3 @@ def test_recover_corrupt_session_moves_file_aside(tmp_path: Path) -> None:
     assert backup.name.startswith("session.json.corrupt-")
     assert not path.exists()
     assert backup.exists()
-

--- a/tests/unit/skills/test_loader.py
+++ b/tests/unit/skills/test_loader.py
@@ -61,6 +61,7 @@ invocation_mode: llm_orchestration
     assert [entry.name for entry in snapshot.skills] == ["echo"]
     assert snapshot.skills[0].source == SkillSource.WORKSPACE
     assert snapshot.skills[0].summary == "workspace echo"
+    assert snapshot.skills[0].instructions == "# Echo"
     assert any(diag.code == "precedence_conflict" for diag in snapshot.diagnostics)
 
 


### PR DESCRIPTION
## Summary
- standardize CommandResult envelope with status/code/message/data
- add deterministic per-session execution lanes to prevent same-session interleaving
- add file-backed session persistence with schema versioning and corrupt-file recovery
- add /help <skill> deterministic metadata command and rich CLI envelope rendering
- expand tests for persistence, reload behavior, lane serialization, and command alias handling

## Verification
- just quality test (clean)
- unit suite includes persistence/recovery/lane and command-surface cases

## Risk Assessment
- medium: touches core command result shape and runtime flow
- mitigations: full quality gate plus 42 unit tests passing locally
- rollback: revert commits on this PR branch if regressions appear

## Checklist (Ruthless)
- [x] behavior is deterministic for command routing and errors
- [x] no hidden fallback behavior introduced
- [x] quality and test gates pass locally (`just quality test`)
- [x] docs/punchlist updated for completed items
