### PR TITLE
docs: split skills platform and supervisor into separate specs

### DIFF
--- a/docs/dev/debt_tracker.md
+++ b/docs/dev/debt_tracker.md
@@ -37,12 +37,12 @@ Priority scale:
 - [ ] Add typed skill/tool contracts (input/output schemas)
   - Owner: `@team`
   - Target: `TBD`
-  - Current state: deterministic envelopes exist, but typed I/O contracts are still deferred.
+  - Current state: typed I/O validation is implemented for `tool_dispatch` command tools, but generalized skill-declared I/O contracts are not yet implemented across all skills/modes.
   - Exit criteria:
-    - skill metadata supports optional typed input/output models
-    - runtime validates input pre-execution and output post-execution
-    - deterministic validation errors implemented
-    - at least 2 skills validated end-to-end
+    - skill metadata supports optional skill-declared input/output schema fields
+    - runtime validates input pre-execution and output post-execution for both `tool_dispatch` and `llm_orchestration`
+    - deterministic validation errors are stable across both execution modes
+    - at least 2 non-demo skills use skill-declared typed I/O end-to-end
 
 - [ ] Add real `/agent <name>` once agent subsystem exists
   - Owner: `@team`

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -11,6 +11,8 @@ Purpose: index active/current specifications.
 
 ## Active Domains
 
+- `docs/specs/agents/skills_platform_v1.md`
+- `docs/specs/agents/supervisor_subagents_v1.md`
 - `docs/specs/memory/memory_spec_v1.md`
 - `docs/specs/memory/memory_eval_governance.md`
 - `docs/specs/commands/persona_commands.md`

--- a/docs/specs/agents/skills_platform_v1.md
+++ b/docs/specs/agents/skills_platform_v1.md
@@ -1,0 +1,203 @@
+---
+owner: "@team"
+last_updated: "2026-02-17"
+status: "active"
+source_of_truth: true
+---
+
+# Skills Platform V1
+
+Status: Proposed  
+Date: 2026-02-17  
+Scope: skill capability contracts, provider registry, isolated code-backed skills, security policy, and typed I/O governance.
+
+## 1. Why This Feature Exists
+
+Current skills support basic `llm_orchestration` and `tool_dispatch`, but lack:
+- explicit capability declarations and enforcement.
+- unified provider abstraction for builtin/MCP/plugin tools.
+- isolated code-backed skill runtime with security controls.
+- full typed contracts across skill execution boundaries.
+
+This feature establishes a secure, deterministic, extensible skills substrate.
+
+## 2. Locked Decisions (V1)
+
+1. Untrusted skill code runs in containers only.
+2. V1 ships one basic profile only: `safe_eval`.
+3. Preflight policy is hard-deny only.
+4. Security approvals are keyed by `(agent_id, skill_id, security_hash)`.
+5. Approval modes are `run_once` and `always_allow`; HITL is default-on.
+6. Write operations are denied by default and require HITL checkpoint.
+7. Durable backend for approval/provenance is SQLite.
+8. TUI approval UX is deferred; terminal prompt is in scope.
+
+## 3. Architecture Contract
+
+## 3.1 Skill Capability Contract
+
+Each skill declares:
+- invocation mode.
+- tool/provider dependencies.
+- typed I/O contract references.
+- isolation and execution policy fields.
+
+Loader validates contracts at snapshot build time; runtime enforces grants at invoke time.
+
+## 3.2 Provider Registry
+
+Use strategy/registry dispatch, not long conditionals:
+- `builtin` provider.
+- `mcp` provider.
+- `plugin` provider.
+
+Resolution path:
+1. validate capability declaration.
+2. resolve provider + tool id.
+3. enforce policy/grant checks.
+4. execute typed request.
+5. validate typed response.
+6. normalize deterministic envelope.
+
+## 3.3 Security and Isolation
+
+- Container boundary for untrusted code.
+- No network by default.
+- Read-only root FS with explicit `/input` read and `/output` write boundaries.
+- Resource limits (CPU/memory/timeout/stdout-stderr caps).
+- Deterministic deny codes for policy/preflight failures.
+
+## 3.4 Security Hash (Locked)
+
+`security_hash` includes:
+- `SKILL.md` full content.
+- declared plugin executable source files.
+- skill metadata/capability contract.
+- execution profile + policy version.
+- container image digest.
+- dependency lock fingerprint.
+- declared behavior-affecting config/assets.
+
+Canonical process:
+- build sorted file manifest with digests.
+- serialize canonical JSON payload.
+- compute SHA-256.
+
+Any hash change invalidates prior approval grants.
+
+## 3.5 Durable Governance Data
+
+Persist in SQLite:
+- approval grants (`run_once`, `always_allow`) keyed by `(agent, skill, hash)`.
+- provenance receipts (hashes, limits, outcome, capped logs metadata).
+
+## 4. Migration Plan (Fixed Scope)
+
+## Phase 1: Capability Contracts + Enforcement
+
+User-visible features:
+- `/skills` diagnostics show capability validation failures.
+
+Internal engineering tasks:
+- extend frontmatter/types for capability contract.
+- add load-time validation + deterministic diagnostics.
+- add invoke-time capability grant enforcement.
+
+Acceptance criteria:
+- malformed/underdeclared skills are excluded with deterministic diagnostics.
+- undeclared tool access fails deterministically.
+- existing bundled skills migrate without behavior regression.
+
+Non-goals:
+- no provider plugins yet.
+- no container runner yet.
+
+Required tests and gates:
+- skill frontmatter/type validation tests.
+- capability enforcement unit tests.
+- `just quality-check` and `just docs-check`.
+
+## Phase 2: Provider Registry (Builtin + MCP)
+
+User-visible features:
+- skills invoke tools via declared provider path.
+
+Internal engineering tasks:
+- implement provider interface and registry map.
+- route existing builtin tools via provider interface.
+- add MCP adapter contract with deterministic error mapping.
+
+Acceptance criteria:
+- registry-based dispatch is used end-to-end.
+- builtin tools remain behavior-compatible.
+- unresolved provider/tool returns deterministic codes.
+
+Non-goals:
+- no code-backed plugin execution yet.
+
+Required tests and gates:
+- registry dispatch unit tests.
+- builtin + mocked MCP integration tests.
+- `just quality-check`.
+
+## Phase 3: Containerized Plugin Runtime + HITL
+
+User-visible features:
+- terminal HITL prompt supports `run_once`, `always_allow`, `deny`.
+- eligible skills can run plugin-backed tools in container sandbox.
+
+Internal engineering tasks:
+- implement plugin entrypoint contract.
+- implement container runner + IPC envelope.
+- add preflight hard-deny checks.
+- add `security_hash` generation + approval cache/store.
+- enforce write requests as explicit HITL checkpoint.
+- persist approvals/provenance in SQLite.
+
+Acceptance criteria:
+- untrusted plugin execution is container-only.
+- unchanged hash can run under cached grant; changed hash requires new approval.
+- preflight denies fail before execution with deterministic codes.
+- write requests always trigger HITL checkpoint.
+
+Non-goals:
+- no subprocess fallback.
+- no auto-rewrite remediation flow.
+- no TUI approval controls.
+
+Required tests and gates:
+- container runner integration tests (ok/timeout/crash).
+- security preflight deny tests.
+- hash approval caching tests.
+- SQLite persistence/reload tests.
+- profile/resource/path enforcement tests.
+- `just quality-check`.
+
+## Phase 4: End-to-End Typed Contract Completion
+
+User-visible features:
+- consistent typed contract behavior across all skill execution paths.
+
+Internal engineering tasks:
+- complete typed I/O for remaining non-typed skill paths.
+- add conformance suite for skill/provider I/O.
+- add regression snapshots for stable error envelopes.
+
+Acceptance criteria:
+- conformance suite covers all supported skill execution paths.
+- typed-contract debt is closed or explicitly narrowed.
+- CI includes contract conformance gate.
+
+Non-goals:
+- no supervisor/subagent orchestration in this feature.
+
+Required tests and gates:
+- contract conformance suite.
+- deterministic envelope snapshot tests.
+- `just quality-check` and `just ci-gates`.
+
+## 5. Deferred Items
+
+- Future `yolo` mode (owner/date TBD).
+- TUI approval controls (tracked under TUI feature).
+

--- a/docs/specs/agents/supervisor_subagents_v1.md
+++ b/docs/specs/agents/supervisor_subagents_v1.md
@@ -1,0 +1,129 @@
+---
+owner: "@team"
+last_updated: "2026-02-17"
+status: "active"
+source_of_truth: true
+---
+
+# Supervisor + Subagents V1
+
+Status: Proposed  
+Date: 2026-02-17  
+Scope: supervisor runtime, subagent delegation, typed handoffs, aggregation, and delegation quality gates.
+
+## 1. Why This Feature Exists
+
+We need first-class orchestration beyond single-skill execution:
+- supervisor planning/routing across specialized subagents.
+- deterministic delegation boundaries and fallback behavior.
+- typed handoff contracts and traceability.
+
+This feature adds orchestration after the skills substrate is hardened.
+
+## 2. Dependency Contract
+
+This feature starts only after `docs/specs/agents/skills_platform_v1.md` gates are complete through:
+- capability contracts + enforcement.
+- provider registry path.
+- deterministic typed envelopes for execution boundaries.
+
+## 3. Architecture Contract
+
+## 3.1 Runtime Roles
+
+- `SupervisorRuntime`: decides plan and delegates work units.
+- `SubagentExecutor`: executes a scoped skill/task with least-privilege capabilities.
+- `Aggregator`: merges subagent outputs into final deterministic envelope.
+
+## 3.2 Delegation Rules
+
+- supervisor is the only component allowed to delegate.
+- subagents cannot recursively delegate in V1.
+- delegation depth is fixed at 1 for V1.
+- each handoff uses typed request/response models.
+- failures are isolated to subagent scope and surfaced deterministically.
+
+## 3.3 Trace and Audit
+
+Record for each delegated run:
+- supervisor run id.
+- subagent call ids and routing decisions.
+- typed handoff payload metadata.
+- outcome and fallback path.
+
+## 4. Migration Plan (Fixed Scope)
+
+## Phase 1: Supervisor Core + Typed Handoff Models
+
+User-visible features:
+- none (internal foundation).
+
+Internal engineering tasks:
+- add supervisor planner interface.
+- add typed handoff request/response models.
+- add deterministic routing config contract.
+
+Acceptance criteria:
+- supervisor can select a target subagent deterministically for supported routes.
+- invalid handoff payloads fail with deterministic contract errors.
+
+Non-goals:
+- no multi-subagent fan-out yet.
+- no user-facing command changes yet.
+
+Required tests and gates:
+- routing unit tests.
+- handoff schema validation tests.
+- `just quality-check`.
+
+## Phase 2: Multi-Subagent Delegation + Aggregation
+
+User-visible features:
+- delegated tasks can involve at least two specialized subagents.
+
+Internal engineering tasks:
+- implement sequential multi-subagent execution path.
+- implement aggregation strategy and fallback contract.
+- enforce isolation of per-subagent failures.
+
+Acceptance criteria:
+- at least one workflow executes 2+ subagents in one run.
+- failed subagent does not crash supervisor run; fallback envelope is deterministic.
+
+Non-goals:
+- no recursive or autonomous background subagents.
+- no open-ended planner loops.
+
+Required tests and gates:
+- integration tests for multi-subagent scenarios.
+- failure containment tests.
+- `just quality-check`.
+
+## Phase 3: Quality Gates + Operational Governance
+
+User-visible features:
+- stable delegation behavior and operator diagnostics.
+
+Internal engineering tasks:
+- add delegation eval suite (correct routing, error containment, output quality).
+- add runbook docs for supervisor/subagent failures.
+- wire delegation evals into CI gate target.
+
+Acceptance criteria:
+- delegation eval thresholds documented and enforced.
+- CI fails on delegation regressions.
+
+Non-goals:
+- no new UI mode (TUI/Studio).
+
+Required tests and gates:
+- eval tests for routing correctness and containment.
+- regression snapshots for delegation envelopes.
+- `just quality-check` and `just eval-gates`.
+
+## 5. Open Questions
+
+- default planning strategy in V1 (rule-based vs model-assisted).
+- session-level vs turn-level supervisor planning state retention.
+- initial canonical subagent set for V1 rollout.
+

--- a/ideas/skills_security.md
+++ b/ideas/skills_security.md
@@ -1,0 +1,1269 @@
+# Chat Export
+
+### User
+
+you had told me about an awesome repl framework i could use. what was it?
+
+---
+
+### Assistant
+
+You’re probably thinking of Textual — that’s the one I most strongly recommend for building a seriously good, modern REPL experience in Python.
+
+Let me quickly recap the main contenders and why Textual usually wins for what you’re doing (Lily / agent tooling / rich CLI workflows).
+
+⭐ 1. Textual — the “awesome” one I likely meant 4 Why it’s a big deal
+
+Textual is basically:
+
+React-style apps… but in the terminal.
+
+You get:
+
+🧱 Layout system (panels, columns, docking)
+
+🧩 Widgets (inputs, tables, logs, trees, tabs)
+
+⚡ Async + event-driven architecture
+
+🎨 Styling with CSS-like syntax
+
+🪄 Smooth updates + animations
+
+⌨️ Keyboard bindings + command palette feel
+
+For your use case (agent orchestration + REPL + observability):
+
+This is perfect because you can build:
+
+REPL input panel
+
+Streaming model output
+
+Agent status windows
+
+Logs + metrics pane
+
+Tool execution monitor
+
+Task queue viewer
+
+Basically a local Studio Control Room inside the terminal.
+
+REPL-style architecture in Textual
+
+Instead of a “classic readline loop”, you build:
+
+scss Copy code App ├── CommandInput widget  (REPL prompt) ├── OutputLog widget     (LLM responses) ├── AgentPanel           (status/metrics) └── Event bus
+
+Commands trigger events → events drive agent actions → UI updates automatically.
+
+That aligns extremely well with your:
+
+LangGraph style orchestration
+
+multi-agent systems
+
+observability-first design
+
+🧠 2. prompt_toolkit — classic REPL power
+
+Prompt Toolkit
+
+This is the engine behind IPython.
+
+Use this when you want:
+
+autocomplete
+
+multiline editing
+
+syntax highlighting
+
+history
+
+vi/emacs modes
+
+If your goal is:
+
+“super powerful command line REPL but still traditional”
+
+this is the correct choice.
+
+BUT…
+
+It’s not a full UI framework.
+
+You can build panels and layouts, but it’s harder and more manual.
+
+🔥 3. Typer + Rich (your current ecosystem)
+
+Typer Rich
+
+You already live here.
+
+Great for:
+
+command-driven tools
+
+scripts
+
+structured CLI workflows
+
+Weak for:
+
+long-running interactive REPL apps
+
+live dashboards
+
+multi-pane interfaces
+
+🧪 4. The “secret weapon” combo I recommended before
+
+This combo is honestly chef’s-kiss for you:
+
+⭐ Textual + prompt_toolkit (inside widgets)
+
+Pattern:
+
+lua Copy code Textual UI
+    ↓
+Command widget uses prompt_toolkit
+    ↓
+Agent orchestration layer
+    ↓
+Streaming output widgets
+
+You get:
+
+modern UI framework
+
+elite REPL behavior
+
+future-proof architecture
+
+This is very close to how high-end internal AI tooling is starting to look.
+
+🧭 What I’d pick for Lily (if we were building today)
+
+Given your goals:
+
+local-first agent system
+
+REPL-like interaction
+
+monitoring agents
+
+command workflows
+
+eventual Studio-style control room
+
+I would do:
+
+yaml Copy code Core shell: Textual REPL input: prompt_toolkit Rendering: Rich (Textual uses it internally) Command surface: Typer commands wrapped as actions
+
+That gives you:
+
+➡️ CLI mode ➡️ REPL mode ➡️ Dashboard mode
+
+…all sharing the same backend.
+
+💥 The mental shift (important)
+
+Don’t think:
+
+“a REPL with extra UI”
+
+Think:
+
+An event-driven TUI that contains a REPL.
+
+That shift is what unlocks agent orchestration.
+
+😏 Honest Iris Opinion
+
+Most people building agent systems today still do:
+
+bash Copy code print(">>>")
+
+and call that a REPL.
+
+If you use Textual, you’ll be building something that feels closer to:
+
+Cursor internal consoles
+
+OpenAI dev tooling
+
+advanced ops dashboards
+
+…and it scales cleanly into the “many agents running” future you keep describing.
+
+If you want, next I can show you something very fun:
+
+🔥 The “Lily REPL architecture” (10/10 design) — the pattern that turns a REPL into a live multi-agent command center without becoming spaghetti.
+
+That one tends to click instantly once you see it.
+
+---
+
+### User
+
+oh, you can make a tui and repl integrated with textual?
+
+---
+
+### Assistant
+
+Yep — Textual is basically made for that.
+
+How it works (the clean mental model)
+
+You don’t build a “REPL app” and then bolt on a TUI.
+
+You build a TUI app with a command input widget that behaves like a REPL:
+
+Top/left/right panes show logs, agent states, tools, metrics
+
+Bottom pane is your prompt / command line
+
+Enter submits → you append to output → kick off async work → stream results back into the output pane
+
+Two good ways to do the REPL input
+
+A) Pure Textual input (simplest)
+
+Use Input (single-line) or TextArea (multiline)
+
+Add history + slash commands yourself
+
+Great if your “REPL” is really “command box + chat”
+
+B) Textual + prompt_toolkit (best REPL ergonomics)
+
+Keep Textual for layout/widgets
+
+Embed prompt_toolkit behavior for:
+
+history
+
+multiline editing
+
+syntax highlighting
+
+tab completion
+
+vi/emacs keybindings
+
+This is the “elite terminal UX” route
+
+What you can build (very relevant to your agent setup)
+
+A single terminal app can show:
+
+Chat/REPL transcript
+
+Live vLLM stream output
+
+Tool execution logs (stdout/stderr)
+
+Agent roster (running / blocked / done)
+
+Queue of tasks (LangGraph node events)
+
+Metrics (tokens/sec, latency, GPU util snapshot, etc.)
+
+Tiny conceptual skeleton (no code, just structure)
+
+App
+
+Header
+
+Container
+
+LogPane (scrolling output)
+
+SidePanel (agents / status)
+
+CommandBar (REPL input)
+
+Footer
+
+On submit:
+
+Echo the command into LogPane
+
+Dispatch an async task to your orchestrator
+
+Stream partial tokens back into LogPane
+
+Update SidePanel as state changes
+
+Practical note with vLLM streaming
+
+Textual plays nicely with streaming because it’s async-first. You can:
+
+consume an async generator of tokens
+
+append to a RichLog / TextLog widget
+
+keep UI responsive while tokens arrive
+
+If you want to move from “yes it’s possible” to “this is our blueprint”, I can lay out a Lily-ready design:
+
+event bus + message types
+
+pane layout
+
+command routing (/run, /tools, /models, /memory)
+
+streaming token plumbing
+
+log provenance hooks (step start/end, tool stderr, artifact hashes)
+
+Just say the vibe you want: minimal chat-first or full control-room.
+
+---
+
+### User
+
+you also told me about a python sandbox tool that is really strong
+
+---
+
+### Assistant
+
+Yeah — the one I was almost certainly talking about is Jupyter, but there are a few “strong sandbox” options depending on what you meant. Let me narrow it down based on what you usually build (agents, REPLs, controlled execution).
+
+🧪 1. Jupyter (the classic heavyweight sandbox) 4
+
+This is the gold standard Python execution sandbox.
+
+Why it’s strong:
+
+Executes code in an isolated kernel
+
+Stateful execution (variables persist)
+
+Rich outputs (plots, tables, HTML)
+
+Easy inspection + debugging
+
+Huge ecosystem
+
+Why I might have mentioned it for you
+
+Because a lot of modern agent systems do:
+
+css Copy code LLM → generates code
+        ↓
+Jupyter-style kernel executes safely
+        ↓
+Result returned to agent
+
+This gives you:
+
+deterministic execution
+
+reproducible sessions
+
+strong introspection
+
+Many “AI coding agents” are basically wrapping a notebook kernel behind the scenes.
+
+🔥 2. IPython — lightweight but powerful REPL sandbox
+
+IPython
+
+This is the engine underneath Jupyter.
+
+If you want:
+
+super-powered Python REPL
+
+history + magic commands
+
+debugging tools
+
+introspection
+
+Then IPython is the cleanest minimal sandbox.
+
+This is often what people mean when they say:
+
+“serious Python REPL”
+
+🧠 3. The one that’s VERY relevant to your agent ideas → Restricted / managed execution environments
+
+The real next-level sandbox (and likely what stuck out when we talked) is:
+
+isolated Python execution via subprocess or container
+
+Pattern:
+
+bash Copy code Agent ↓ Execution Manager ↓ Temporary sandbox ├─ venv ├─ resource limits ├─ timeout └─ controlled imports
+
+This is how:
+
+OpenAI code interpreters
+
+research agents
+
+autonomous coding systems
+
+avoid blowing up the host system.
+
+Typical tools people use:
+
+Python subprocess
+
+Docker containers
+
+uv-managed envs (you’ll like this)
+
+temporary working directories
+
+⭐ The VERY strong modern option (the one I think you’ll love) Jupyter kernel as a backend sandbox
+
+This is the trick advanced systems use:
+
+You DON’T show notebooks.
+
+Instead:
+
+csharp Copy code Lily/TUI (Textual)
+        ↓
+Command → execution request
+        ↓
+Jupyter kernel runs code
+        ↓
+Results streamed back into TUI
+
+You get:
+
+safe-ish isolated execution
+
+incremental state
+
+rich outputs
+
+strong debugging
+
+Basically:
+
+Sandbox + REPL + agent execution engine all in one.
+
+🧭 If I had to map this to YOUR ecosystem
+
+Given:
+
+Textual TUI
+
+vLLM agents
+
+UV workflow
+
+multi-agent execution
+
+I’d recommend:
+
+🥇 “Lily-level” architecture java Copy code Textual UI (TUI + REPL)
+        ↓
+Command router
+        ↓
+Execution Manager
+        ↓
+Jupyter kernel (sandbox)
+        ↓
+Streaming results → UI
+
+This lets you safely execute generated code while monitoring everything live.
+
+😏 Honest Iris take
+
+Most people trying to build agent sandboxes:
+
+❌ reinvent execution isolation badly
+
+The smartest move:
+
+✔️ Reuse Jupyter/IPython kernels as the execution brain.
+
+You get 10+ years of battle-tested sandbox behavior for free.
+
+If you want, I can tell you the one Python sandbox that agent builders quietly use once they get serious — it’s a level up from Jupyter and fits frighteningly well with your “many agents + control room” vision.
+
+---
+
+### User
+
+what is the url for the restricted
+
+---
+
+### Assistant
+
+If you’re thinking of the RestrictedPython project (the common “restricted execution” sandbox people mention in Python agent discussions), the official URL is:
+
+➡️ https://github.com/zopefoundation/RestrictedPython
+
+Quick clarity (important)
+
+RestrictedPython is not a full security sandbox by itself.
+
+It gives you:
+
+restricted language subset
+
+blocked builtins
+
+controlled globals/locals
+
+safer evaluation of untrusted code
+
+But it does not fully protect against:
+
+OS escapes
+
+resource exhaustion
+
+process abuse
+
+So the real-world pattern is usually:
+
+scss Copy code RestrictedPython
+        +
+Process isolation (Docker / subprocess / container)
+        +
+Resource limits (timeouts, memory caps)
+
+Why people use it anyway
+
+Because it’s great for:
+
+LLM-generated code filtering
+
+plugin systems
+
+user scripting
+
+educational environments
+
+It limits what Python syntax can do before execution even happens.
+
+For your Lily / agent ecosystem
+
+Honestly — and this is me steering you toward the stronger architecture — most advanced agent builders end up doing:
+
+cpp Copy code Container sandbox ├── uv / venv ├── resource limits ├── temp filesystem └── optional RestrictedPython layer
+
+RestrictedPython = first line of defense Container isolation = real safety boundary
+
+If you want, next I can show you the “Google-level safe agent execution stack” — the layered architecture that turns agent code execution from scary → boringly reliable. That one maps perfectly onto your control-room vision.
+
+---
+
+### User
+
+please do
+
+---
+
+### Assistant
+
+Alright Jeff — here’s the “boringly reliable” safe agent execution stack I’d use if I were building Lily to run LLM-generated code without turning your workstation into a crime scene.
+
+The Google-level safe agent execution stack
+
+Think layers, where each layer assumes the one above it can fail.
+
+Layer 0 — Policy gate (before any code exists)
+
+Goal: prevent obviously bad requests from ever becoming code.
+
+Disallow: network access, file exfil, credential reads, system config changes, fork bombs
+
+Force: explicit I/O contract (“inputs are X, outputs must be Y”)
+
+Require: “dry-run plan” first (what it intends to do)
+
+Implementation: simple rule engine + allowlist of operations per “skill”.
+
+Layer 1 — Static scan (code linting + AST checks)
+
+Goal: catch risky patterns cheaply before running anything.
+
+Parse AST and block:
+
+import os, import subprocess, import socket, import requests, open(...) (unless explicitly allowed)
+
+eval, exec, compile
+
+dunder abuse (__import__, __subclasses__, etc.)
+
+Enforce limits:
+
+max lines / nodes / recursion hints
+
+max string literal size (prevents “data blob smuggling”)
+
+Tools: Python ast + your own checks (fast, deterministic).
+
+Layer 2 — Restricted language (optional)
+
+Goal: shrink the language surface area.
+
+This is where RestrictedPython can help if you’re doing user scripting/plugin-style code.
+
+But: treat it as defense-in-depth, not “the sandbox.”
+
+Layer 3 — Process isolation (the real boundary)
+
+Goal: the code runs somewhere that can’t hurt you.
+
+You run code in a separate process at minimum; ideally a container.
+
+Baseline: subprocess + low-privilege user + temp directory Better: Docker rootless or Podman, with hard constraints
+
+Key container settings:
+
+no network (default for untrusted code)
+
+read-only filesystem except a mounted /work
+
+non-root user
+
+seccomp/apparmor (where available)
+
+cap drop all
+
+pids limit (prevents fork bombs)
+
+memory / CPU quotas
+
+timeout
+
+Layer 4 — Resource limits (kills the “runs forever” class)
+
+Goal: stop hangs, bombs, and accidental “train a model” moments.
+
+wall-clock timeout (hard kill)
+
+CPU quota
+
+memory limit
+
+disk quota
+
+output size limit (stdout/stderr cap)
+
+max files created
+
+max processes/threads
+
+Linux helpers:
+
+cgroups (containers already use them)
+
+ulimit / resource module (when using subprocess)
+
+pids controller
+
+Layer 5 — Filesystem & artifact boundary (no mystery I/O)
+
+Goal: everything in/out is explicit and audited.
+
+Only allow:
+
+read from /input (mounted)
+
+write to /output (mounted)
+
+all other paths read-only or absent
+
+Outputs must be:
+
+declared types (json, png, csv, md)
+
+size limited
+
+hashed for provenance
+
+Layer 6 — Observability + provenance (trust through receipts)
+
+Goal: every run is explainable, replayable, attributable.
+
+Log:
+
+code hash
+
+input artifact hashes
+
+environment hash (uv lock hash, python version, container image digest)
+
+start/end time
+
+resource usage summary
+
+exit code
+
+stdout/stderr (capped)
+
+This is what makes “agent execution” feel like engineering.
+
+Layer 7 — Review gates (human-in-the-loop when needed)
+
+Goal: choose when to require approval.
+
+Trigger review when:
+
+tries to touch filesystem outside contract
+
+tries to install packages
+
+high resource demand
+
+novel imports / suspicious AST patterns
+
+first time running a new “skill”
+
+A concrete “safe default” profile (what I’d ship first)
+
+Default: NO network, read-only rootfs, /work temp only, 10s timeout, 1 CPU, 512MB RAM, stdout capped.
+
+Then have profiles:
+
+safe_eval (math/string/formatting)
+
+data_processing (pandas/numpy allowed)
+
+plotting (matplotlib allowed)
+
+repo_tooling (limited filesystem access, still no network)
+
+networked (explicit allow + strict egress rules)
+
+Implementation blueprint for Lily (clean and modular) 1) ExecutionRequest (typed)
+
+language: python
+
+code: string
+
+inputs: list of artifacts
+
+allowed_imports: allowlist
+
+io_contract: read paths / write paths
+
+limits: cpu/mem/time/output caps
+
+profile: enum
+
+2) SandboxRunner interface
+
+run(request) -> ExecutionResult
+
+Backends:
+
+SubprocessRunner (fast dev mode)
+
+ContainerRunner (production-safe)
+
+3) PolicyEngine
+
+merges profile defaults + per-skill overrides
+
+decides review required vs auto-run
+
+4) ProvenanceLogger
+
+writes a run folder with logs + hashes
+
+This maps perfectly to your Layer 5/6 “observability and reproducibility” docs from Lily.
+
+The URLs you’ll actually want (the building blocks)
+
+RestrictedPython (language restriction): https://github.com/zopefoundation/RestrictedPython
+
+Podman (rootless containers): https://podman.io/
+
+gVisor (extra container isolation): https://gvisor.dev/
+
+Firejail (Linux sandbox tool, alternative style): https://firejail.wordpress.com/
+
+(If you’re doing this on WSL2, Podman/Docker-based isolation is usually the most straightforward.)
+
+My recommendation for you, specifically
+
+Given you’re already running local infra (vLLM, WSL, uv), I’d do:
+
+ContainerRunner-first (don’t start with “clever restrictions”)
+
+No network by default
+
+/input + /output mounts only
+
+Tight limits + provenance logs
+
+Optional RestrictedPython later for plugin scripts
+
+That gives you safety and the “control room” vibe you want.
+
+If you want the next step, I’ll write you a minimal spec + folder layout for this subsystem inside Lily (interfaces, Pydantic models, and the exact Docker/Podman run flags).
+
+---
+
+### User
+
+are there any libraries to help with the AST checking
+
+---
+
+### Assistant
+
+Yes — there are some very solid libraries that make AST checking much easier than hand-rolling visitors over Python’s ast module. Since you’re building a serious agent sandbox, I’ll group them by how people actually use them in production.
+
+🛡️ 1. Bandit — security-focused AST scanning (HIGHLY recommended)
+
+Bandit
+
+This is probably the closest thing to what you want if your goal is:
+
+“scan generated code for dangerous patterns before execution.”
+
+Bandit:
+
+parses Python → builds AST
+
+runs rule plugins over nodes
+
+flags security risks automatically
+
+Examples it catches:
+
+subprocess usage
+
+unsafe deserialization
+
+shell injection patterns
+
+unsafe eval/exec patterns
+
+It literally says in the docs:
+
+it builds an AST and runs plugins against AST nodes GitHub +1
+
+Why this is great for Lily
+
+You don’t need to invent rules from scratch.
+
+You can:
+
+arduino Copy code Agent code → Bandit scan → pass/fail → sandbox run
+
+Huge shortcut.
+
+🧠 2. astroid — smarter AST with inference
+
+astroid
+
+If Python’s built-in AST feels too dumb — this is what advanced tooling uses.
+
+astroid adds:
+
+type-ish inference
+
+scope awareness
+
+symbol resolution
+
+richer node model
+
+It’s what powers pylint and similar tooling.
+
+From the project:
+
+supports static inference and local scopes GitHub +1
+
+Use when:
+
+You want checks like:
+
+“is this really subprocess or aliased?”
+
+“what import does this resolve to?”
+
+“is this value potentially dangerous?”
+
+This is next-level for agent safety.
+
+✨ 3. LibCST — AST but safer & lossless
+
+LibCST
+
+This is VERY important for you.
+
+Why?
+
+Normal AST:
+
+❌ loses comments + formatting ❌ hard to rewrite safely
+
+LibCST:
+
+preserves formatting/comments
+
+allows safe rewriting
+
+perfect for transformations
+
+It was built for codemods and linters. GitHub
+
+Agent safety superpower
+
+Instead of just rejecting code, you can:
+
+auto-rewrite imports
+
+strip dangerous calls
+
+patch code before execution
+
+Example:
+
+scss Copy code remove os.system() rewrite open() → safe_open() inject guards
+
+This is how serious AI coding pipelines evolve.
+
+🔥 4. The “pro” stack most AI-agent systems converge toward
+
+This is the part people don’t tell beginners:
+
+You rarely choose ONE.
+
+You layer them:
+
+pgsql Copy code LibCST → normalize / rewrite code
+       ↓
+Bandit → security rule scan
+       ↓
+astroid → deeper semantic checks
+       ↓
+Sandbox execution
+
+That combo is extremely powerful.
+
+🧪 Bonus — community direction (what people actually use)
+
+From dev discussions:
+
+LibCST is widely used for transforms/refactoring workflows Reddit
+
+tools even combine LibCST + LLMs for large rewrites Reddit
+
+Meaning:
+
+➡️ This is a very modern direction — not legacy tooling.
+
+💡 My recommendation for Lily specifically
+
+Since you’re building:
+
+agent execution
+
+trusted sandbox
+
+long-lived platform
+
+I would do this:
+
+Phase 1 (fast + strong) diff Copy code Bandit (pre-execution scan) + Simple custom AST checks
+
+You get safety fast.
+
+Phase 2 (Google-level) arduino Copy code LibCST rewrite layer → normalize code → remove risky patterns → enforce safe wrappers
+
+Now the agent can “fix itself” automatically.
+
+Phase 3 (Iris-approved power move)
+
+Add astroid for:
+
+alias resolution
+
+smart import tracing
+
+semantic safety rules
+
+At this stage you’re building something closer to internal AI tooling.
+
+🎯 If you want the real cheat code
+
+I’ll tell you the exact 10 AST checks that catch ~90% of dangerous LLM-generated code in agent systems.
+
+These are the rules serious agent builders quietly converge on — and they map perfectly onto your sandbox architecture.
+
+---
+
+### User
+
+please do
+
+---
+
+### Assistant
+
+Absolutely. Here are 10 AST checks that catch the vast majority of “LLM code went feral” cases, without turning your sandbox into a brittle mess.
+
+I’m going to assume your default posture is: no network, no shell, no arbitrary filesystem, unless a specific “execution profile” allows it.
+
+1) Block dynamic code execution
+
+What to catch
+
+eval(...), exec(...), compile(...)
+
+ast.parse(...)+exec, types.FunctionType(...) (if you want to be strict)
+
+Why This is the #1 “escape hatch” for getting around every other check.
+
+AST target
+
+ast.Call where func resolves to eval\|exec\|compile
+
+2) Block dynamic imports / module loaders
+
+What to catch
+
+__import__(...)
+
+importlib.import_module(...)
+
+importlib.reload(...) (optional)
+
+pkgutil, runpy, zipimport (often unnecessary in sandboxes)
+
+Why If you only allowlist imports, dynamic import is how code bypasses it.
+
+AST target
+
+ast.Call to __import__ or attribute calls to importlib.*
+
+3) Enforce an import allowlist (and detect aliases)
+
+What to catch
+
+Any import X / from X import Y not in allowlist
+
+Aliasing (e.g., import subprocess as sp) is fine, but must still be allowlisted
+
+Why Most “danger” enters via imports.
+
+AST target
+
+ast.Import, ast.ImportFrom
+
+Tip Maintain profiles, e.g.:
+
+safe_eval: math, statistics, re, json, datetime
+
+data_processing: add numpy, pandas
+
+plotting: add matplotlib
+
+4) Block OS / shell / process execution primitives
+
+What to catch
+
+subprocess.* (run, Popen, call, check_output, etc.)
+
+os.system, os.popen, pty, shlex (shlex often used for command building)
+
+ctypes (often used for low-level access)
+
+signal + custom handlers (optional)
+
+multiprocessing (optional; can be used for fork bombs)
+
+Why This is how you get command execution, persistence, and process spawning.
+
+AST target
+
+ast.Attribute calls with base name os/subprocess/...
+
+plus import checks above
+
+5) Block network and IPC by default
+
+What to catch
+
+socket
+
+urllib, http.client
+
+requests, aiohttp
+
+ftplib, smtplib
+
+websockets
+
+grpc (if you ever see it, it’s almost never “needed” in a sandbox)
+
+Why Even if containers have no network, you still want to fail fast and log intent.
+
+AST target
+
+imports + calls to socket.socket, requests.get, etc.
+
+6) Block filesystem writes outside declared safe paths
+
+What to catch
+
+open(path, mode) where mode implies write/append/create: w, a, x, +
+
+pathlib.Path(...).write_text/write_bytes/mkdir/unlink/rmdir/rename/replace
+
+os.remove, os.unlink, os.rmdir, shutil.rmtree, shutil.copy*, shutil.move
+
+Why You want artifact-boundary I/O only: /input read, /output write.
+
+AST target
+
+ast.Call to open
+
+ast.Call to attribute names like write_text, rmtree, etc.
+
+Important detail Statically, you often can’t know the real path. Use a rule like:
+
+allow literal paths only (strict mode), OR
+
+require that file paths originate from an injected safe helper like ctx.output_path("x.json")
+
+7) Cap output / logging flood (print storms)
+
+What to catch
+
+giant print() inside loops
+
+while True with printing
+
+writing huge strings to stdout
+
+Why This is the common “agent stalls your TUI and eats memory” failure mode.
+
+AST target
+
+ast.While with test True
+
+ast.For / ast.While containing print() or sys.stdout.write()
+
+Heuristic Flag if:
+
+print appears inside any loop AND no obvious bounded range (range(N) where N is a small constant) is detectable.
+
+8) Kill the classic infinite loop / runaway recursion patterns
+
+What to catch
+
+while True: without a break or without a decreasing counter (heuristic)
+
+recursion without base case (hard statically, but you can flag obvious cases)
+
+Why Even with timeouts, you want early rejection and better error messages.
+
+AST target
+
+ast.While where test is ast.Constant(True)
+
+optionally, scan body for ast.Break presence
+
+9) Block introspection / “dunder escape” gadgets
+
+What to catch
+
+Access to attributes like:
+
+__globals__, __getattribute__, __subclasses__, __mro__, __dict__
+
+func.__code__, co_consts, f_locals, frame usage
+
+inspect module (often used to reach frames)
+
+Why A lot of Python sandbox escapes pivot through object model introspection.
+
+AST target
+
+ast.Attribute with attr starting/ending __
+
+imports of inspect, gc (sometimes used to find objects)
+
+Rule of thumb If you see __subclasses__, treat it like a red alert unless you explicitly allow it.
+
+10) Ban package installation / environment mutation
+
+What to catch
+
+pip invoked via subprocess, os.system
+
+sys.path.append(...) / site.addsitedir(...) (optional but smart)
+
+importlib.machinery / importlib.util.spec_from_file_location (often used to load arbitrary code)
+
+writing to .pth or site-packages paths
+
+Why This is how code makes itself “stick” or pulls in new capabilities.
+
+AST target
+
+calls touching sys.path, site.*, importlib.* loaders
+
+plus your process execution checks
+
+The practical “profile” approach (how this stays sane)
+
+Instead of one mega-policy, define profiles:
+
+SAFE_EVAL: only pure computation + formatting
+
+No filesystem writes
+
+No network
+
+Tiny import allowlist
+
+DATA_PROCESSING: allow /input reads and /output writes
+
+allow numpy/pandas
+
+still no network, no subprocess
+
+PLOTTING: allow matplotlib and write images to /output
+
+REPO_TOOLING: allow limited filesystem within a workspace mount (still no shell by default)
+
+Each profile = allowlist imports + allowed IO helpers + limits.
+
+One power move that makes these checks way stronger
+
+Inject a ctx object and require all side effects go through it:
+
+ctx.read_text("input.csv")
+
+ctx.write_json("result.json", data)
+
+ctx.log("...")
+
+Then your AST checks can be stricter:
+
+ban raw open()
+
+ban print()
+
+ban direct Path.write_*
+
+That massively reduces risk and increases observability.
+
+If you want, I can turn these into:
+
+a rule table (RuleID, severity, node types, examples, message), and
+
+a minimal AST checker skeleton (built-in ast) that supports profiles + alias tracking + clear error reporting for Lily’s control-room UI.

--- a/ideas/tui_repl.md
+++ b/ideas/tui_repl.md
@@ -1,0 +1,213 @@
+You’re probably thinking of **Textual** — that’s the one I most strongly recommend for building a *seriously good*, modern REPL experience in Python.
+
+Let me quickly recap the main contenders and why Textual usually wins for what you’re doing (Lily / agent tooling / rich CLI workflows).
+
+---
+
+## ⭐ 1. Textual — the “awesome” one I likely meant
+
+![Image](https://raw.githubusercontent.com/zabertech/zaber-examples/refs/heads/main/examples/gui_textual/img/screenshot.png)
+
+![Image](https://repository-images.githubusercontent.com/355959597/b9a0a7e1-0b51-4b36-a571-384500b7c528)
+
+![Image](https://www.textualize.io/static/img/dolphie.png)
+
+![Image](https://raw.githubusercontent.com/Textualize/textual/main/imgs/textual.png)
+
+### Why it’s a big deal
+
+Textual is basically:
+
+> **React-style apps… but in the terminal.**
+
+You get:
+
+* 🧱 Layout system (panels, columns, docking)
+* 🧩 Widgets (inputs, tables, logs, trees, tabs)
+* ⚡ Async + event-driven architecture
+* 🎨 Styling with CSS-like syntax
+* 🪄 Smooth updates + animations
+* ⌨️ Keyboard bindings + command palette feel
+
+For your use case (agent orchestration + REPL + observability):
+
+This is *perfect* because you can build:
+
+* REPL input panel
+* Streaming model output
+* Agent status windows
+* Logs + metrics pane
+* Tool execution monitor
+* Task queue viewer
+
+Basically a **local Studio Control Room** inside the terminal.
+
+---
+
+### REPL-style architecture in Textual
+
+Instead of a “classic readline loop”, you build:
+
+```
+App
+ ├── CommandInput widget  (REPL prompt)
+ ├── OutputLog widget     (LLM responses)
+ ├── AgentPanel           (status/metrics)
+ └── Event bus
+```
+
+Commands trigger events → events drive agent actions → UI updates automatically.
+
+That aligns *extremely* well with your:
+
+* LangGraph style orchestration
+* multi-agent systems
+* observability-first design
+
+---
+
+## 🧠 2. prompt_toolkit — classic REPL power
+
+Prompt Toolkit
+
+This is the **engine behind IPython**.
+
+Use this when you want:
+
+* autocomplete
+* multiline editing
+* syntax highlighting
+* history
+* vi/emacs modes
+
+If your goal is:
+
+> “super powerful command line REPL but still traditional”
+
+this is the correct choice.
+
+BUT…
+
+It’s not a full UI framework.
+
+You *can* build panels and layouts, but it’s harder and more manual.
+
+---
+
+## 🔥 3. Typer + Rich (your current ecosystem)
+
+Typer
+Rich
+
+You already live here.
+
+Great for:
+
+* command-driven tools
+* scripts
+* structured CLI workflows
+
+Weak for:
+
+* long-running interactive REPL apps
+* live dashboards
+* multi-pane interfaces
+
+---
+
+## 🧪 4. The “secret weapon” combo I recommended before
+
+This combo is honestly chef’s-kiss for you:
+
+### ⭐ Textual + prompt_toolkit (inside widgets)
+
+Pattern:
+
+```
+Textual UI
+    ↓
+Command widget uses prompt_toolkit
+    ↓
+Agent orchestration layer
+    ↓
+Streaming output widgets
+```
+
+You get:
+
+* modern UI framework
+* elite REPL behavior
+* future-proof architecture
+
+This is very close to how high-end internal AI tooling is starting to look.
+
+---
+
+## 🧭 What I’d pick for Lily (if we were building today)
+
+Given your goals:
+
+* local-first agent system
+* REPL-like interaction
+* monitoring agents
+* command workflows
+* eventual Studio-style control room
+
+I would do:
+
+```
+Core shell: Textual
+REPL input: prompt_toolkit
+Rendering: Rich (Textual uses it internally)
+Command surface: Typer commands wrapped as actions
+```
+
+That gives you:
+
+➡️ CLI mode
+➡️ REPL mode
+➡️ Dashboard mode
+
+…all sharing the same backend.
+
+---
+
+## 💥 The mental shift (important)
+
+Don’t think:
+
+> “a REPL with extra UI”
+
+Think:
+
+> **An event-driven TUI that contains a REPL.**
+
+That shift is what unlocks agent orchestration.
+
+---
+
+## 😏 Honest Iris Opinion
+
+Most people building agent systems today still do:
+
+```
+print(">>>")
+```
+
+and call that a REPL.
+
+If you use **Textual**, you’ll be building something that feels closer to:
+
+* Cursor internal consoles
+* OpenAI dev tooling
+* advanced ops dashboards
+
+…and it scales cleanly into the “many agents running” future you keep describing.
+
+---
+
+If you want, next I can show you something *very* fun:
+
+🔥 **The “Lily REPL architecture” (10/10 design)** — the pattern that turns a REPL into a live multi-agent command center without becoming spaghetti.
+
+That one tends to click instantly once you see it.


### PR DESCRIPTION
## Summary
This PR separates the previously combined skills/supervisor planning into two independent feature specs and updates active spec indexing.

## Fully complete in this PR
- Added docs/specs/agents/skills_platform_v1.md as the source-of-truth spec for skills capability upgrades/security/tooling/runtime policy.
- Added docs/specs/agents/supervisor_subagents_v1.md as the source-of-truth spec for supervisor/subagent orchestration.
- Updated docs/specs/README.md active spec index to point to both new specs.
- Updated debt wording in docs/dev/debt_tracker.md to reflect current typed-contract state precisely.
- Added planning/reference notes in ideas/skills_security.md and ideas/tui_repl.md.

## Compatibility / temporary
- These are planning/spec changes only; no runtime behavior changes are included.
- TUI approval UX remains explicitly deferred; terminal HITL prompt is documented as current scope for the skills feature.

## Deferred
- Implementation of skills platform phases (capability enforcement, providers, container runtime, approvals store).
- Implementation of supervisor/subagent runtime phases.
- Future YOLO mode decision remains deferred.

## Validation
- just docs-check passed.
