### PR TITLE
docs: create issue drafts for open debt tracker items

### DIFF
--- a/docs/dev/debt_tracker.md
+++ b/docs/dev/debt_tracker.md
@@ -24,6 +24,7 @@ Priority scale:
 ### P1
 
 - [ ] Eliminate third-party deprecation warning workaround (`trustcall`)
+  - Issue draft: `docs/dev/issues/debt/debt-p1-trustcall-warning.md`
   - Owner: `@team`
   - Target: `2026-03-15`
   - Current state: pytest suppresses `trustcall._base` deprecation warning about `Send` import path.
@@ -33,6 +34,7 @@ Priority scale:
     - quality/test runs remain warning-clean
 
 - [ ] Add pre-execution language restriction layer (RestrictedPython or equivalent AST policy)
+  - Issue draft: `docs/dev/issues/debt/debt-p1-language-restriction-layer.md`
   - Owner: `@team`
   - Target: `2026-03-08`
   - Current state: V1 security relies on container isolation + hard-deny preflight patterns; no RestrictedPython-style language restriction is enforced before plugin execution.
@@ -60,6 +62,7 @@ Priority scale:
     - full gate run passes with plugin active via `just quality test`
 
 - [ ] Unify duplicated memory repository behavior across file/store backends
+  - Issue draft: `docs/dev/issues/debt/debt-p2-unify-memory-repository-core.md`
   - Owner: `@team`
   - Target: `2026-03-20`
   - Current state:
@@ -73,6 +76,7 @@ Priority scale:
 ### P3
 
 - [ ] Add scheduled jobs for run-artifact cleanup and self-learning pipelines
+  - Issue draft: `docs/dev/issues/debt/debt-p3-scheduled-jobs-cleanup-self-learning.md`
   - Owner: `@team`
   - Target: `TBD`
   - Current state: V0 jobs retain all artifacts by default; no periodic cleanup/self-learning orchestration jobs are defined.
@@ -82,6 +86,7 @@ Priority scale:
     - runbook covers enabling/disabling and observing these scheduled jobs
 
 - [ ] Consolidate runtime SQLite locations under `.lily/db/`
+  - Issue draft: `docs/dev/issues/debt/debt-p3-consolidate-runtime-sqlite-location.md`
   - Owner: `@team`
   - Target: `TBD`
   - Current state: SQLite artifacts are split across directories (for example `.lily/checkpoints/checkpointer.sqlite` and planned `.lily/db/security.sqlite`).
@@ -91,6 +96,7 @@ Priority scale:
     - docs/config defaults are updated and tested for migration safety
 
 - [ ] Add multi-process persistence safety strategy
+  - Issue draft: `docs/dev/issues/debt/debt-p3-multiprocess-persistence-safety.md`
   - Owner: `@team`
   - Target: `TBD`
   - Current state: per-session serialization exists, but multi-process locking strategy is not finalized.
@@ -100,6 +106,7 @@ Priority scale:
     - concurrency tests include multi-process cases
 
 - [ ] Split oversized test modules into focused suites
+  - Issue draft: `docs/dev/issues/debt/debt-p3-split-oversized-test-modules.md`
   - Owner: `@team`
   - Target: `2026-03-10`
   - Current state:

--- a/docs/dev/issues/debt/README.md
+++ b/docs/dev/issues/debt/README.md
@@ -1,0 +1,17 @@
+# Debt Issue Drafts
+
+This directory contains issue drafts created from open items in `docs/dev/debt_tracker.md`.
+
+## Internal engineering tasks
+
+- [P1] Eliminate third-party deprecation warning workaround (`trustcall`) (`debt-p1-trustcall-warning.md`)
+- [P1] Add pre-execution language restriction layer (`debt-p1-language-restriction-layer.md`)
+- [P2] Unify duplicated memory repository behavior (`debt-p2-unify-memory-repository-core.md`)
+- [P3] Add scheduled jobs for cleanup and self-learning (`debt-p3-scheduled-jobs-cleanup-self-learning.md`)
+- [P3] Consolidate runtime SQLite locations under `.lily/db/` (`debt-p3-consolidate-runtime-sqlite-location.md`)
+- [P3] Add multi-process persistence safety strategy (`debt-p3-multiprocess-persistence-safety.md`)
+- [P3] Split oversized test modules into focused suites (`debt-p3-split-oversized-test-modules.md`)
+
+## User-visible features
+
+- None. These debt issues are internal engineering tasks.

--- a/docs/dev/issues/debt/debt-p1-language-restriction-layer.md
+++ b/docs/dev/issues/debt/debt-p1-language-restriction-layer.md
@@ -1,0 +1,31 @@
+# [Debt][P1] Add pre-execution language restriction layer (RestrictedPython or equivalent AST policy)
+
+## Source
+- Debt tracker: `docs/dev/debt_tracker.md` (Active Debt → P1)
+
+## Internal engineering tasks
+- Implement deterministic pre-execution restriction for plugin code.
+- Stabilize denial codes/messages and cover them with tests.
+- Document layered security model: language restriction + container isolation.
+
+## User-visible features
+- None.
+
+## Acceptance criteria
+- A deterministic pre-execution restriction layer is active for plugin code.
+- Denial codes/messages are stable and test-covered.
+- Docs explicitly describe the layered security model.
+
+## Non-goals
+- Replacing container isolation boundary.
+- Shipping a full sandbox redesign.
+
+## Required tests and gates
+- Security-focused unit tests for deny/allow behavior.
+- Contract/integration tests for stable denial envelopes.
+- `just quality test` warning-clean.
+
+## Metadata
+- Priority: `P1`
+- Owner: `@team`
+- Target: `2026-03-08`

--- a/docs/dev/issues/debt/debt-p1-trustcall-warning.md
+++ b/docs/dev/issues/debt/debt-p1-trustcall-warning.md
@@ -1,0 +1,30 @@
+# [Debt][P1] Eliminate third-party deprecation warning workaround (`trustcall`)
+
+## Source
+- Debt tracker: `docs/dev/debt_tracker.md` (Active Debt → P1)
+
+## Internal engineering tasks
+- Upgrade/fix dependency path so no suppression is required.
+- Remove warning filter entry from `pyproject.toml`.
+- Keep quality/test runs warning-clean.
+
+## User-visible features
+- None.
+
+## Acceptance criteria
+- The `trustcall._base` deprecation warning about `Send` import path no longer appears in test/runtime output.
+- Warning suppression for this warning is removed from `pyproject.toml`.
+- `just quality test` passes warning-clean.
+
+## Non-goals
+- Refactoring unrelated warning filters.
+- Broad dependency upgrades not required for this warning path.
+
+## Required tests and gates
+- `just quality test`
+- Targeted pytest invocation covering paths that previously emitted the warning.
+
+## Metadata
+- Priority: `P1`
+- Owner: `@team`
+- Target: `2026-03-15`

--- a/docs/dev/issues/debt/debt-p2-unify-memory-repository-core.md
+++ b/docs/dev/issues/debt/debt-p2-unify-memory-repository-core.md
@@ -1,0 +1,31 @@
+# [Debt][P2] Unify duplicated memory repository behavior across file/store backends
+
+## Source
+- Debt tracker: `docs/dev/debt_tracker.md` (Active Debt → P2)
+
+## Internal engineering tasks
+- Create a shared repository core for policy/validation/upsert/filter/sort behavior.
+- Convert file/store repositories into thin backend I/O adapters.
+- Add parity tests across backends for core operations.
+
+## User-visible features
+- None.
+
+## Acceptance criteria
+- Shared core service (or equivalent) owns common repository behavior.
+- File/store repositories are thin adapters.
+- Cross-backend parity tests validate equivalent behavior.
+
+## Non-goals
+- Introducing new memory features beyond behavior parity.
+- Changing memory API contracts unless required for parity.
+
+## Required tests and gates
+- Unit tests for shared core behavior.
+- Cross-backend parity tests.
+- `just quality test` warning-clean.
+
+## Metadata
+- Priority: `P2`
+- Owner: `@team`
+- Target: `2026-03-20`

--- a/docs/dev/issues/debt/debt-p3-consolidate-runtime-sqlite-location.md
+++ b/docs/dev/issues/debt/debt-p3-consolidate-runtime-sqlite-location.md
@@ -1,0 +1,31 @@
+# [Debt][P3] Consolidate runtime SQLite locations under `.lily/db/`
+
+## Source
+- Debt tracker: `docs/dev/debt_tracker.md` (Active Debt → P3)
+
+## Internal engineering tasks
+- Define canonical runtime DB directory as `.lily/db/`.
+- Migrate or compatibility-map existing SQLite paths.
+- Update docs/config defaults and validate migration safety.
+
+## User-visible features
+- None.
+
+## Acceptance criteria
+- Canonical runtime DB location is `.lily/db/`.
+- Existing SQLite paths are migrated or compatibility-mapped safely.
+- Docs/config defaults are updated and migration path is tested.
+
+## Non-goals
+- Replacing SQLite with another storage technology.
+- Data model redesign unrelated to path consolidation.
+
+## Required tests and gates
+- Migration and backward-compatibility tests.
+- Startup/runtime tests with pre-existing directories.
+- `just quality test` warning-clean.
+
+## Metadata
+- Priority: `P3`
+- Owner: `@team`
+- Target: `TBD`

--- a/docs/dev/issues/debt/debt-p3-multiprocess-persistence-safety.md
+++ b/docs/dev/issues/debt/debt-p3-multiprocess-persistence-safety.md
@@ -1,0 +1,31 @@
+# [Debt][P3] Add multi-process persistence safety strategy
+
+## Source
+- Debt tracker: `docs/dev/debt_tracker.md` (Active Debt → P3)
+
+## Internal engineering tasks
+- Define lock strategy for session/checkpoint/memory paths.
+- Define conflict/failure behavior.
+- Add multi-process concurrency tests.
+
+## User-visible features
+- None.
+
+## Acceptance criteria
+- Lock strategy is documented and implemented for persistence paths.
+- Conflict/failure behavior is explicit and deterministic.
+- Concurrency test suite includes multi-process cases.
+
+## Non-goals
+- Distributed locking across multiple hosts.
+- Full persistence subsystem rewrite.
+
+## Required tests and gates
+- Multi-process concurrency tests.
+- Failure-path tests for lock contention and recovery.
+- `just quality test` warning-clean.
+
+## Metadata
+- Priority: `P3`
+- Owner: `@team`
+- Target: `TBD`

--- a/docs/dev/issues/debt/debt-p3-scheduled-jobs-cleanup-self-learning.md
+++ b/docs/dev/issues/debt/debt-p3-scheduled-jobs-cleanup-self-learning.md
@@ -1,0 +1,31 @@
+# [Debt][P3] Add scheduled jobs for run-artifact cleanup and self-learning pipelines
+
+## Source
+- Debt tracker: `docs/dev/debt_tracker.md` (Active Debt → P3)
+
+## Internal engineering tasks
+- Define and implement cleanup job spec + retention policy.
+- Define self-learning cadence + safety gates.
+- Provide runbook for enable/disable and observability.
+
+## User-visible features
+- None.
+
+## Acceptance criteria
+- Explicit cleanup job spec and retention policy implemented.
+- Explicit self-learning cadence and safety gates defined.
+- Runbook covers operational controls and observability.
+
+## Non-goals
+- Shipping new end-user product capabilities unrelated to scheduling.
+- One-off manual cleanup scripts as final solution.
+
+## Required tests and gates
+- Job scheduling/integration tests.
+- Operational runbook validation checklist.
+- `just quality test` warning-clean.
+
+## Metadata
+- Priority: `P3`
+- Owner: `@team`
+- Target: `TBD`

--- a/docs/dev/issues/debt/debt-p3-split-oversized-test-modules.md
+++ b/docs/dev/issues/debt/debt-p3-split-oversized-test-modules.md
@@ -1,0 +1,31 @@
+# [Debt][P3] Split oversized test modules into focused suites
+
+## Source
+- Debt tracker: `docs/dev/debt_tracker.md` (Active Debt → P3)
+
+## Internal engineering tasks
+- Split command-surface tests by domain (skills/persona/memory/jobs).
+- Split CLI tests by concern (bootstrap/run/repl/rendering).
+- Preserve behavior contract coverage while improving reviewability.
+
+## User-visible features
+- None.
+
+## Acceptance criteria
+- `tests/unit/commands/test_command_surface.py` is split into focused suites.
+- `tests/unit/cli/test_cli.py` is split into focused suites.
+- No behavior contract coverage is lost.
+
+## Non-goals
+- Changing command or CLI behavior semantics.
+- Rewriting unrelated test infrastructure.
+
+## Required tests and gates
+- Full unit test run for command + CLI suites.
+- Contract regression checks for command behavior.
+- `just quality test` warning-clean.
+
+## Metadata
+- Priority: `P3`
+- Owner: `@team`
+- Target: `2026-03-10`


### PR DESCRIPTION
### Motivation
- Ensure every open item in the canonical debt tracker has an actionable, in-repo issue draft with clear acceptance criteria and tests so work can be planned and assigned. 
- Improve traceability between the debt register and concrete engineering tasks by linking each unchecked debt item to a corresponding draft. 

### Description
- Added a new directory `docs/dev/issues/debt/` and an index `README.md` listing the drafts and classifying them as internal engineering tasks. 
- Created seven issue draft files (`debt-p1-trustcall-warning.md`, `debt-p1-language-restriction-layer.md`, `debt-p2-unify-memory-repository-core.md`, `debt-p3-scheduled-jobs-cleanup-self-learning.md`, `debt-p3-consolidate-runtime-sqlite-location.md`, `debt-p3-multiprocess-persistence-safety.md`, `debt-p3-split-oversized-test-modules.md`) each with acceptance criteria, non-goals, and required tests/gates. 
- Updated `docs/dev/debt_tracker.md` to include an `Issue draft` reference under every currently unchecked debt item. 

### Testing
- Executed a verification script (`python - <<'PY' ... PY`) that asserts the count of open items in `docs/dev/debt_tracker.md`, the number of `Issue draft` references, and the number of `docs/dev/issues/debt/debt-*.md` files are equal, and the assertion passed. 
- This is a documentation-only change with low risk and no runtime code paths affected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bd48b4e88326835404d1ad4f6bac)