### PR TITLE
docs(skills): align SI-007 docs to Claude guide and close 006

### DIFF
--- a/.ai/PLANS/005-skills-system-implementation.md
+++ b/.ai/PLANS/005-skills-system-implementation.md
@@ -190,6 +190,7 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
 - [ ] Phase 6: CLI surfaces (`skills list/inspect/doctor`) and UX
 - [ ] Phase 7: Telemetry/events, diagnostics, and observability
 - [ ] Phase 8: Testing, docs/status sync, and release hardening
+- [ ] Phase 9: Post-MVP distribution and packaging follow-up
 
 ### Phase 0: Execution framing and acceptance lock
 
@@ -219,7 +220,8 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
 - **Source of truth**: PRD `Skill package contract`; Architecture `SKILL.md contract` and metadata schema.
 - **Must**:
   - [ ] Implement strict pydantic models for skill metadata/frontmatter and normalized summaries.
-  - [ ] Enforce snake_case IDs, known enum types, and required fields.
+  - [ ] Enforce guide-aligned required fields (`name`, `description`) and parser normalization rules.
+  - [ ] Enforce canonical kebab-case recommendation as lint/doctor guidance (not hard reject for imported third-party skills).
   - [ ] Provide clear field-level errors (no generic parse failures).
 - **Must Not**:
   - [ ] Introduce implicit fallback defaults for required fields.
@@ -236,6 +238,8 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
 - [ ] ADD deterministic validation messages for each required field.
 - [ ] ADD fixture packs for success/failure contracts.
 - [ ] ADD unit tests for parsing, unknown fields, malformed versions, and ID validation.
+- [ ] ADD parser test matrix for malformed YAML/frontmatter edge cases (missing delimiters, unclosed quotes, bad YAML types, forbidden `<` `>` values, reserved provider prefixes).
+- [ ] ADD normalization tests for non-canonical names -> internal canonical key mapping.
 
 ### Phase 2: Discovery, indexing, precedence, and registry
 
@@ -293,6 +297,13 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
   - [ ] Implement playbook/procedural/agent adapters behind a registry dispatch map.
   - [ ] Enforce skill-level policy checks before execution.
   - [ ] Keep delegated agent execution context-bounded and auditable.
+  - [ ] Implement normative tool policy resolution:
+    - omitted `allowed-tools` follows config mode:
+      - `inherit_runtime` => inherit runtime-available tool set;
+      - `deny_unless_allowed` => empty skill candidate tool set;
+      - `use_default_packs` => tool union from configured default packs;
+    - present `allowed-tools` => explicit skill list wins, then intersect with runtime-available tool set;
+    - empty effective tool set => playbook-only allowed, tool-call paths fail fast.
 - **Must Not**:
   - [ ] Implement adapter selection with fragile long condition chains.
   - [ ] Allow explicit invocation to bypass deny policies.
@@ -301,6 +312,8 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
 - **Acceptance gates**:
   - [ ] Unit tests for each adapter success/failure path.
   - [ ] Integration tests for denylist, tool allowlist, and agent allowlist enforcement.
+  - [ ] Unit/integration tests proving omitted `allowed-tools` does not over-restrict skills and cannot expand runtime boundaries.
+  - [ ] Unit tests for all three default policy modes and explicit `allowed-tools` override precedence.
 
 **Tasks**
 - [ ] CREATE `skill_policies.py` with typed check results and rejection reasons.
@@ -308,6 +321,12 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
 - [ ] ADD procedural wrapper contract validation (input/output schema).
 - [ ] ADD agent adapter bounds (`max_iterations`, tool/model call limits).
 - [ ] ADD policy-focused tests preventing bypass via explicit invocation.
+- [ ] ADD policy tests for tool resolution matrix: omitted `allowed-tools`, explicit subset, explicit empty set, and out-of-runtime tool entries.
+- [ ] UPDATE config schema/loader to support:
+  - [ ] `skills.tools.default_policy`
+  - [ ] `skills.tools.default_packs`
+  - [ ] `skills.tools.packs`
+- [ ] ADD config validation tests for unknown pack IDs, unknown tool IDs in packs, and duplicate pack entries.
 
 ### Phase 5: Runtime integration into supervisor invoke path
 
@@ -341,6 +360,7 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
   - [ ] Add `skills list`, `skills inspect`, `skills doctor` user-facing commands.
   - [ ] Use Rich tables/panels for default outputs.
   - [ ] Surface collisions/shadowing/invalid packages with actionable messages.
+  - [ ] Surface trigger quality diagnostics (under-trigger and over-trigger heuristics) with actionable remediation guidance.
 - **Must Not**:
   - [ ] Default to raw JSON in interactive mode.
   - [ ] Hide policy-block reasons from operator diagnostics.
@@ -356,6 +376,8 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
 - [ ] ADD filtering/sorting flags and concise/verbose modes.
 - [ ] ADD e2e tests for no-skills, valid-skills, invalid-skills scenarios.
 - [ ] ADD docs snippets for command usage.
+- [ ] ADD `skills doctor` trigger test templates: should-trigger, paraphrase-trigger, should-not-trigger.
+- [ ] ADD operator remediation docs for under-trigger/over-trigger tuning in description/frontmatter.
 
 ### Phase 7: Telemetry/events and observability
 
@@ -387,6 +409,7 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
 - **Must**:
   - [ ] Run full quality/test gates warning-clean.
   - [ ] Update roadmap/status/backlog/debt docs to reflect completion/defer states.
+  - [ ] Record explicit guide-alignment evidence for parser matrix and trigger/UX diagnostics.
   - [ ] Produce phased commits following commit policy (feature, UX polish, docs-only as applicable).
 - **Must Not**:
   - [ ] Merge with unresolved warning debt undocumented.
@@ -403,6 +426,31 @@ Use markdown checkboxes (`- [ ]`) for implementation phases and task bullets so 
 - [ ] RUN full gates and capture output in execution report.
 - [ ] UPDATE docs status surfaces with SI-007 phase truth.
 - [ ] PREPARE PR using repository template headings exactly.
+- [ ] ADD implementation evidence section mapping guide checklist items -> shipped tests/commands.
+
+### Phase 9: Post-MVP distribution and packaging follow-up
+
+**Intent Lock**
+- **Source of truth**: SI-007 PRD `## 13. Future Considerations`; SKILLS_ARCHITECTURE `## 20. Tight Delta Checklist (Guide Realignment)`.
+- **Must**:
+  - [ ] Define zip/import-export package contract for portable skill bundles.
+  - [ ] Define API-managed skill lifecycle/versioning strategy for programmatic deployments.
+  - [ ] Define org-level distribution, rollout, and governance policy surfaces.
+- **Must Not**:
+  - [ ] Block SI-007 MVP closure on post-MVP distribution implementation.
+  - [ ] Ship ad hoc packaging behavior without documented contract/versioning.
+- **Provenance map**:
+  - [ ] Distribution requirements in architecture/PRD map to a tracked follow-up plan and backlog entries.
+- **Acceptance gates**:
+  - [ ] A follow-up implementation plan exists and is linked from roadmap/backlog.
+  - [ ] Deferred scope is explicitly documented in PR/status surfaces.
+
+**Tasks**
+- [ ] CREATE follow-up plan file for distribution work (next plan ID after current active plans).
+- [ ] DEFINE skill bundle archive format (layout, checksum, manifest metadata, compatibility fields).
+- [ ] DEFINE import/export CLI/API surfaces and validation error taxonomy.
+- [ ] DEFINE rollout strategy: org publish/update channels, version pinning, rollback semantics.
+- [ ] UPDATE roadmap/backlog/status docs to track distribution track separately from SI-007 MVP.
 
 ---
 

--- a/.ai/PLANS/006-skills-docs-realignment-claude-guide.md
+++ b/.ai/PLANS/006-skills-docs-realignment-claude-guide.md
@@ -1,0 +1,113 @@
+# Feature: SI-007 Skills Docs Realignment to Claude Guide
+
+## Feature Description
+
+Realign Lily skills documentation contracts to match `docs/ideas/The-Complete-Guide-to-Building-Skill-for-Claude.pdf` so Lily can consume externally-authored skills with minimal friction.
+
+## Traceability Mapping
+
+- Roadmap system improvements: `SI-007`
+- Debt items: `None`
+- No SI/DEBT mapping for this feature: `Not applicable`
+
+## Branch Setup
+
+```bash
+PLAN_FILE=".ai/PLANS/006-skills-docs-realignment-claude-guide.md"
+PLAN_SLUG="$(basename "$PLAN_FILE" .md)"
+BRANCH_NAME="feat/${PLAN_SLUG}"
+git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}" \
+  && git switch "${BRANCH_NAME}" \
+  || git switch -c "${BRANCH_NAME}"
+```
+
+## Implementation Plan
+
+- [x] Phase 1: Update SI-007 PRD contract language
+  - [x] Intent Lock
+    - [x] Source of truth: Claude skills PDF + `.ai/SPECS/002-skills-system/PRD.md`
+    - [x] Must: require only `name` and `description` in frontmatter
+    - [x] Must: clarify naming policy (`kebab-case` recommendation and normalization)
+    - [x] Must: capture PDF security restrictions in explicit bullets
+    - [x] Must Not: require extra metadata fields for baseline compatibility
+    - [x] Acceptance gates: spec text is explicit and non-contradictory
+
+- [x] Phase 2: Update skills architecture implementation contract
+  - [x] Intent Lock
+    - [x] Source of truth: Claude skills PDF + `.ai/SPECS/002-skills-system/SKILLS_ARCHITECTURE.md`
+    - [x] Must: define parser/normalization behavior and compatibility mode
+    - [x] Must: include full optional frontmatter field list from PDF
+    - [x] Must: define strict validation/security rules matching PDF
+    - [x] Must Not: introduce runtime behavior not represented in current SI-007 scope
+    - [x] Acceptance gates: architecture sections map directly to PRD and PDF
+
+- [x] Phase 3: Add tight delta checklist for execution
+  - [x] Intent Lock
+    - [x] Source of truth: updated SI-007 PRD + SKILLS_ARCHITECTURE
+    - [x] Must: produce concise checklist with "aligned/partial/missing" closure tasks
+    - [x] Must: include future distribution/packaging work as explicit deferred scope
+    - [x] Must Not: leave ambiguous ownerless follow-ups
+    - [x] Acceptance gates: checklist is actionable and implementation-ready
+
+## Required Tests and Gates
+
+- Docs consistency/readability check (manual review of contradictions)
+- `just docs-check`
+
+## Definition of Visible Done
+
+- A reader can open SI-007 PRD and architecture docs and see:
+  - only `name` and `description` are required in frontmatter;
+  - naming convention and normalization policy are explicit;
+  - PDF security guardrails are explicitly listed;
+  - future distribution/API packaging work is explicitly documented as follow-up;
+  - a tight delta checklist defines what to implement next.
+
+## Execution Report
+
+### Completion Status
+
+- Completed (docs-only realignment scope).
+
+### Artifacts Updated
+
+- `.ai/SPECS/002-skills-system/PRD.md`
+- `.ai/SPECS/002-skills-system/SKILLS_ARCHITECTURE.md`
+- `.ai/PLANS/005-skills-system-implementation.md`
+- `.ai/PLANS/006-skills-docs-realignment-claude-guide.md`
+
+### What Was Realigned
+
+- Frontmatter contract aligned to guide baseline:
+  - required keys: `name`, `description`
+  - optional keys documented: `license`, `compatibility`, `allowed-tools`, `metadata`
+- Naming policy clarified:
+  - kebab-case recommended for authoring
+  - non-canonical imports accepted and normalized to internal canonical key
+- Security guardrails explicitly documented:
+  - reject `<` and `>` in frontmatter values
+  - reject reserved `name` prefixes (`claude*`, `anthropic*`)
+  - safe YAML parsing only
+- Tight delta checklist added and closed to `[aligned]` by linking explicit work into implementation plan phases.
+- Distribution/packaging follow-up explicitly tracked in `005` Phase 9.
+- Skills tool-policy modes added to specs and plan:
+  - `inherit_runtime`
+  - `deny_unless_allowed`
+  - `use_default_packs`
+  - plus precedence/invariants and YAML/TOML config examples.
+
+### Validation Notes
+
+- `ReadLints` run for updated docs files: no diagnostics.
+
+### Key Decisions / Deviations
+
+- **Naming enforcement strategy**:
+  - Decision: recommend kebab-case for skill `name` and folder naming, but do not hard-reject imported third-party non-canonical names.
+  - Rationale: maximize compatibility with externally-authored skills while still converging local authoring toward a canonical convention.
+  - Implementation intent: normalize non-canonical names to an internal canonical key for indexing/matching; preserve original author-facing `name` in metadata and CLI output.
+
+- **Tool policy default behavior**:
+  - Decision: make omitted `allowed-tools` behavior configurable via global policy (`inherit_runtime`, `deny_unless_allowed`, `use_default_packs`) instead of one fixed default.
+  - Rationale: different deployments need different security postures (convenience-first vs least-privilege by default).
+  - Implementation intent: explicit `allowed-tools` on a skill overrides default policy, and runtime/tool-registry boundaries remain the hard upper bound.

--- a/.ai/SPECS/002-skills-system/PRD.md
+++ b/.ai/SPECS/002-skills-system/PRD.md
@@ -64,7 +64,7 @@ Core principles:
 ### In Scope
 
 #### Core functionality
-- ✅ Skill package contract with required `SKILL.md` and metadata/frontmatter.
+- ✅ Skill package contract with required `SKILL.md` and YAML frontmatter.
 - ✅ Local skill discovery from configured skill roots.
 - ✅ Skill indexing and deterministic selection pipeline.
 - ✅ Progressive disclosure loading model (summary index + full body on select).
@@ -183,8 +183,15 @@ src/lily/runtime/
 ### F1. Skill package specification
 
 - Required artifact: `SKILL.md`.
-- Required metadata fields (frontmatter or equivalent index): `id`, `name`, `description`, `type`, `tags`, `version`.
-- Optional artifacts: examples, references, scripts, tests, assets.
+- Required frontmatter fields: `name`, `description`.
+- Optional frontmatter fields (guide-aligned): `license`, `compatibility`, `allowed-tools`, `metadata`.
+- Optional artifacts: `scripts/`, `references/`, `assets/`.
+
+Naming and compatibility policy:
+- Canonical authoring recommendation: `name` should be kebab-case and should match folder name.
+- Runtime compatibility behavior: parser accepts non-canonical imported names but normalizes to an internal canonical key for indexing/matching.
+- Normalization is internal-only; original author-facing `name` is preserved in loaded metadata.
+- `SKILL.md` filename is exact/case-sensitive; no in-skill `README.md` (keep docs in `SKILL.md` and `references/`).
 
 Acceptance:
 - deterministic parse failures with field-specific errors.
@@ -230,6 +237,12 @@ Acceptance:
 - Enable/disable by scope or skill ID.
 - Agent-level skill allowlist/denylist.
 - Optional manual-approval gates for high-risk skills.
+
+Tool-access resolution policy (normative):
+- Runtime boundary remains authoritative: skills cannot grant access to tools outside `agent.* tools.allowlist` and global runtime policies.
+- If `allowed-tools` is omitted in skill frontmatter: apply no additional skill-level restriction (skill inherits runtime-available tools).
+- If `allowed-tools` is present: effective tools are `intersection(runtime_available_tools, skill_allowed_tools)`.
+- If `allowed-tools` resolves to an empty effective set: skill may still load for playbook-only behavior, but any tool-calling path must fail fast with deterministic policy error messaging.
 
 Acceptance:
 - blocked skills cannot be invoked implicitly or explicitly.
@@ -280,6 +293,10 @@ Acceptance:
 - Enforce skill allowlist/denylist and execution policy boundaries.
 - Restrict agent-skill delegation through explicit policy and max-call limits.
 - Log and surface unsafe/blocked invocation attempts.
+- Enforce frontmatter security restrictions aligned with the guide:
+  - reject XML angle brackets (`<` and `>`) in frontmatter values;
+  - reject reserved provider prefixes in skill `name` (`claude*`, `anthropic*`);
+  - parse YAML with safe loading only (no executable YAML tags).
 
 ### Security out of scope (post-MVP)
 
@@ -295,8 +312,59 @@ Agent config (`agent.yaml`/`agent.toml`):
 - `skills.allowlist` / `skills.denylist`
 - `skills.implicit_selection.enabled`
 - `skills.selection.max_candidates`
+- `skills.tools.default_policy` (`inherit_runtime` | `deny_unless_allowed` | `use_default_packs`)
+- `skills.tools.default_packs` (list of named pack IDs)
+- `skills.tools.packs` (map of pack ID -> ordered tool ID list)
 
 Optional skill catalog (`skills.yaml`/`skills.toml`) for explicit registrations.
+
+Tool-policy mode semantics:
+- `inherit_runtime`:
+  - if skill omits `allowed-tools`, skill inherits runtime-available tools.
+- `deny_unless_allowed`:
+  - if skill omits `allowed-tools`, skill has no tool access (playbook-only behavior still allowed).
+- `use_default_packs`:
+  - if skill omits `allowed-tools`, effective tools come from union of configured `default_packs`.
+
+Precedence and safety:
+- Runtime boundary remains authoritative; skills cannot grant tools outside runtime policy.
+- Effective skill tools are always intersected with runtime-available tools.
+- If both `allowed-tools` and default packs are present for one skill, explicit `allowed-tools` wins.
+
+Example config (YAML):
+```yaml
+skills:
+  enabled: true
+  roots:
+    - .lily/skills
+  scopes_precedence: [repository, user, system]
+  tools:
+    default_policy: use_default_packs
+    default_packs: [core-research, docs-safe]
+    packs:
+      core-research:
+        - web_search
+        - web_fetch
+      docs-safe:
+        - read_file
+        - rg
+```
+
+Example config (TOML):
+```toml
+[skills]
+enabled = true
+roots = [".lily/skills"]
+scopes_precedence = ["repository", "user", "system"]
+
+[skills.tools]
+default_policy = "use_default_packs"
+default_packs = ["core-research", "docs-safe"]
+
+[skills.tools.packs]
+core-research = ["web_search", "web_fetch"]
+docs-safe = ["read_file", "rg"]
+```
 
 ---
 
@@ -425,6 +493,11 @@ Estimated timeline (engineering weeks):
 - Skill effectiveness scoring and promotion workflows.
 - Remote skill package distribution with provenance checks.
 - Automated extraction of candidate skills from execution traces.
+- Distribution/packaging follow-up:
+  - zip/package validation and import/export workflow for skill bundles;
+  - compatibility profile for cross-platform skill portability;
+  - API-managed skill lifecycle and version rollout strategy;
+  - organization-wide publishing/update/governance controls.
 
 ---
 

--- a/.ai/SPECS/002-skills-system/SKILLS_ARCHITECTURE.md
+++ b/.ai/SPECS/002-skills-system/SKILLS_ARCHITECTURE.md
@@ -142,6 +142,11 @@ src/lily/commands/handlers/
   agents/<skill_id>.py
 ```
 
+Critical packaging rules (guide-aligned):
+- `SKILL.md` filename is exact and case-sensitive.
+- Skill folder naming recommendation is kebab-case (portability-friendly baseline).
+- Do not place `README.md` inside a skill folder; keep skill docs in `SKILL.md` and `references/`.
+
 ### `SKILL.md` contract
 
 Required:
@@ -160,25 +165,26 @@ Recommended:
 ### Metadata/frontmatter contract
 
 ```yaml
-id: literature_review
-name: Literature Review
-version: 0.1.0
-type: playbook
-description: Structured synthesis workflow for papers.
-tags: [research, synthesis, papers]
-triggers:
-  - literature review
-  - review related work
-policy:
-  enabled: true
-  allow_agents: [lily_supervisor]
-  tool_allowlist: [arxiv_search, summarize]
+name: literature-review
+description: Structured synthesis workflow for papers. Use when user asks for literature review or related-work synthesis.
+license: MIT
+compatibility: Claude Code / local Lily runtime with MCP enabled
+allowed-tools: "Bash(python:*) WebFetch"
+metadata:
+  author: Team
+  version: 0.1.0
+  mcp-server: arxiv
+  tags: [research, synthesis, papers]
 ```
 
 Validation rules:
-- `id` snake_case and unique after precedence resolution.
-- `type` in enum.
-- unknown required-contract fields fail fast.
+- required frontmatter keys are only `name` and `description`.
+- `name` authoring recommendation: kebab-case and folder-aligned.
+- parser accepts non-canonical imported names, then normalizes to an internal canonical key for index/matching.
+- `description` must include both WHAT the skill does and WHEN to use it (trigger guidance).
+- `description` max length: 1024 chars.
+- unknown required-contract violations fail fast with field-specific errors.
+- safe YAML parsing only (no executable YAML tags).
 
 ---
 
@@ -213,7 +219,7 @@ Proposed scope order (configurable):
 ### Routing order
 
 1. explicit invocation (`$skill:<id>`) when present
-2. exact `id` or alias match
+2. exact normalized-key or alias match
 3. implicit scoring match (description + tags + trigger cues)
 4. no-skill fallback to normal runtime path
 
@@ -319,6 +325,66 @@ Invariant:
 - restricted tool allowlist per skill (optional but recommended).
 - schema validation before execution.
 - refusal path for blocked skills with actionable diagnostics.
+- frontmatter content restrictions:
+  - reject XML angle brackets (`<` and `>`) in frontmatter values;
+  - reject reserved provider prefixes in `name` (`claude*`, `anthropic*`).
+
+### Tool access resolution (normative)
+
+Config inputs (agent config):
+- `skills.tools.default_policy`: `inherit_runtime` | `deny_unless_allowed` | `use_default_packs`
+- `skills.tools.default_packs`: list of pack IDs
+- `skills.tools.packs`: mapping of pack ID -> ordered tool ID list
+
+Resolution algorithm:
+1. Start with `runtime_available_tools` from existing runtime/tool registry policy boundaries.
+2. Resolve skill candidate set:
+   - if skill defines `allowed-tools`: `skill_candidate_tools = allowed-tools` (explicit wins)
+   - else if policy is `inherit_runtime`: `skill_candidate_tools = runtime_available_tools`
+   - else if policy is `deny_unless_allowed`: `skill_candidate_tools = []`
+   - else if policy is `use_default_packs`: `skill_candidate_tools = union(default_packs[*])`
+3. Compute effective tools:
+   - `effective_tools = runtime_available_tools ∩ skill_candidate_tools`
+4. If `effective_tools` is empty:
+   - playbook-only execution remains allowed;
+   - any procedural/agent/tool-call path fails fast with deterministic `SkillPolicyError`.
+
+Invariants:
+- skill metadata can only restrict tool access; it cannot expand tool access beyond runtime policy.
+- explicit invocation does not bypass tool policy resolution.
+- unknown pack IDs or unknown tools in packs fail fast at config-validation time.
+
+Reference config shapes:
+
+YAML:
+```yaml
+skills:
+  tools:
+    default_policy: deny_unless_allowed
+    default_packs: [safe-readonly]
+    packs:
+      safe-readonly:
+        - read_file
+        - rg
+        - web_fetch
+```
+
+TOML:
+```toml
+[skills.tools]
+default_policy = "deny_unless_allowed"
+default_packs = ["safe-readonly"]
+
+[skills.tools.packs]
+safe-readonly = ["read_file", "rg", "web_fetch"]
+```
+
+### Frontmatter optional fields (guide-aligned)
+
+- `license`
+- `compatibility`
+- `allowed-tools`
+- `metadata` (custom key-values such as author/version/mcp-server/tags/documentation/support)
 
 ### Provenance and audit
 
@@ -615,6 +681,38 @@ Benefit:
 2. Should agent-skill wrappers require explicit per-skill tool allowlists at launch?
 3. What is the minimum operator UX for skill debugging in TUI?
 4. Which tie-break signals are acceptable before adding embeddings?
+
+---
+
+## 20. Tight Delta Checklist (Guide Realignment)
+
+Status legend:
+- `[aligned]` complete in spec
+- `[partial]` present but needs refinement
+- `[missing]` not yet specified clearly
+
+Contract and naming:
+- `[aligned]` `SKILL.md` is required.
+- `[aligned]` required frontmatter is only `name` + `description`.
+- `[aligned]` kebab-case naming is recommended; normalization behavior is required via parser + `skills doctor` tests (planned in `.ai/PLANS/005-skills-system-implementation.md`, Phases 1 and 6).
+
+Progressive disclosure and execution:
+- `[aligned]` three-level load model is defined (summary, body, linked artifacts).
+- `[aligned]` playbook/procedural/agent execution paths are defined.
+
+Security guardrails:
+- `[aligned]` angle-bracket rejection in frontmatter is explicit.
+- `[aligned]` reserved provider prefixes (`claude*`, `anthropic*`) are blocked.
+- `[aligned]` parser test matrix for malformed YAML/frontmatter edge cases is required in implementation plan (`.ai/PLANS/005-skills-system-implementation.md`, Phase 1).
+
+Authoring and validation UX:
+- `[aligned]` trigger-test templates (trigger/paraphrase/negative) are required in docs + `skills doctor` (`.ai/PLANS/005-skills-system-implementation.md`, Phase 6).
+- `[aligned]` over-trigger/under-trigger remediation guidance is required in operator docs (`.ai/PLANS/005-skills-system-implementation.md`, Phase 6).
+
+Distribution and packaging (future work):
+- `[aligned]` zip/import-export package contract is tracked as post-MVP in `.ai/PLANS/005-skills-system-implementation.md` (Phase 9).
+- `[aligned]` API-managed skill lifecycle/versioning is tracked as post-MVP in `.ai/PLANS/005-skills-system-implementation.md` (Phase 9).
+- `[aligned]` org-level distribution, rollout, and governance surfaces are tracked as post-MVP in `.ai/PLANS/005-skills-system-implementation.md` (Phase 9).
 
 ---
 


### PR DESCRIPTION
# Summary

Realign SI-007 skills documentation to the Claude skills guide so Lily can consume externally authored skills with clear, deterministic policy behavior. Include a security gate unblock by upgrading `pyjwt` to remediate the audit finding discovered during `/phase-close` validation.

## Problem / Motivation

The skills specs and plan needed tighter compatibility with the external guide (minimal frontmatter contract, naming compatibility posture, security guardrails, and tool policy semantics). During close-out validation, `pip-audit` also failed on `pyjwt 2.11.0` (`CVE-2026-32597`), which blocked phase closure.

## Approach

Updated SI-007 PRD + architecture + implementation plan to:
- align required frontmatter to `name`/`description` with guide-compatible optional fields,
- define normalization and security restrictions explicitly,
- define normative tool-resolution behavior including config-driven defaults,
- map all prior partial/missing checklist items into executable plan phases,
- add YAML/TOML config examples for `skills.tools` behavior.

Applied a minimal dependency remediation for the security gate failure by raising `pyjwt` to a fixed version and refreshing lock state.

---

# What Changed

## User-facing / Contract Changes

- Skills contract docs now define guide-aligned frontmatter and security rules.
- Skills tool access behavior is now explicitly configurable via:
  - `skills.tools.default_policy`
  - `skills.tools.default_packs`
  - `skills.tools.packs`

## Key Changes (bullets)

- Updated `.ai/SPECS/002-skills-system/PRD.md` with guide-aligned contract language, tool policy semantics, and YAML/TOML examples.
- Updated `.ai/SPECS/002-skills-system/SKILLS_ARCHITECTURE.md` with normative tool-resolution algorithm and checklist closure mapping.
- Updated `.ai/PLANS/005-skills-system-implementation.md` to include missing execution tasks/tests and post-MVP distribution phase.
- Finalized `.ai/PLANS/006-skills-docs-realignment-claude-guide.md` execution report and decisions.
- Updated `pyproject.toml` + `uv.lock` to upgrade `pyjwt` to `2.12.1`.

## Out of Scope

- Runtime implementation of SI-007 code modules under `src/lily/runtime`.
- PR creation/merge for SI-007 feature implementation itself.

---

# Verification

## Required Gates

- [x] `/cleanup` run (quality + tests) and **green**
- [x] `/coverage` run (coverage threshold) and **green**
- [x] `/test-quality` considered (new tests follow quality standards)

## Tests Added / Updated

- None (docs + dependency/security remediation only).

## How to Reproduce / Validate

```bash
just quality && just test
just test-cov
just docs-check
just status
```

---

# Risk Assessment

## Risk Level

- [x] Low (localized change, strong tests, minimal surface area)
- [ ] Medium (touches core paths, moderate surface area, good tests)
- [ ] High (wide surface area, complex behavior, or migration involved)

## Failure Modes Considered

- Misinterpreted skills tool policy defaults could produce unsafe/over-restrictive behavior in implementation.
- Security audit failure could block close-out and CI if dependency remained vulnerable.

## Rollback Plan

- Revert commits `a08ad50` and/or `3c611fb`.
- Re-run `just quality && just test` to confirm baseline restoration.

---

# Performance / Scalability

## Perf Impact

- [x] No measurable impact expected
- [ ] Potential improvement
- [ ] Potential regression (explain below)

---

# Compatibility / Migration

## Breaking Change?

- [x] No
- [ ] Yes (details below)

## Config / Schema Changes

- [x] None
- [ ] Yes (details below)

---

# Documentation Impact

- [ ] No docs update needed
- [x] Docs updated in this PR (list paths below)
- [ ] Docs follow-up required (owner + target date below)

Updated docs:
- `.ai/SPECS/002-skills-system/PRD.md`
- `.ai/SPECS/002-skills-system/SKILLS_ARCHITECTURE.md`
- `.ai/PLANS/005-skills-system-implementation.md`
- `.ai/PLANS/006-skills-docs-realignment-claude-guide.md`

---

# Security / Privacy

- [x] No secrets/keys added
- [x] No sensitive data logged
- [x] No new external network calls (or documented below)

Security note:
- `pyjwt` upgraded to fixed version (`2.12.1`) to resolve `CVE-2026-32597` surfaced by `pip-audit`.

---

# Code Health

## Debt / Follow-ups

- Execute `.ai/PLANS/005-skills-system-implementation.md` Phase 1 onward for runtime implementation.
- Track post-MVP distribution tasks under Phase 9.

## Reviewer Notes

- Focus review on SI-007 contract clarity and internal consistency across PRD, architecture, and plan artifacts.

---

# Checklist (Ruthless)

## PR Hygiene

- [x] PR is **single-purpose** (no mixed refactor + feature + drive-by formatting)
- [x] No generated artifacts or caches committed
- [x] No debug prints / commented code left behind
- [x] Names and docs updated where needed
- [x] Errors are actionable (type + key context; not fragile string matching)

## Test Quality (non-negotiable)

- [x] Tests assert **behavior/contracts**, not implementation details
- [x] Mocks only at boundaries; no deep mock chains
- [x] Exception tests do **not** exact-match full message strings
- [x] Tests are deterministic (seeded randomness, no wall-clock reliance)
- [x] Tests are readable (AAA structure, clear naming, one reason to fail)

## Coverage Quality

- [x] Added tests cover high-value logic (not “coverage padding”)
- [x] Edge cases and failure paths included where meaningful
- [x] Coverage improvements map to confidence improvements